### PR TITLE
Enhance XML metadata, canonicalisation, and hunt/profile integration

### DIFF
--- a/docs/format-support.md
+++ b/docs/format-support.md
@@ -8,11 +8,11 @@ aligned.
 
 | Format family            | Variants / focus                                                 | Plugin | Module version | Status       | Notes |
 |--------------------------|------------------------------------------------------------------|--------|----------------|--------------|-------|
-| Structured configuration | `.config` web/app/machine files, build transforms, assembly sidecars | xml    | 0.0.1          | Stabilising  | Transform precedence and schema provenance work remain on the roadmap. |
-| Generic XML              | Application manifests (`.manifest`), resources (`.resx`), XAML UI | xml    | 0.0.1          | Stabilising  | Namespace logging lands in metadata; canonical diff tooling still evolving. |
+| Structured configuration | `.config` web/app/machine files, build transforms, assembly sidecars | xml    | 0.0.2          | Stabilising  | Schema discovery (xsi:*) and layered transform precedence now surface in metadata. |
+| Generic XML              | Application manifests (`.manifest`), resources (`.resx`), XAML UI | xml    | 0.0.2          | Stabilising  | Canonicaliser preserves namespace order and exposes schema references for reporting highlights. |
 | JSON                     | Generic JSON, comment-friendly `jsonc`, `appsettings*.json`      | json   | 0.0.1          | Preview      | Large-sample validation and sampling guardrails are still being tuned. |
 
-Last updated: 2025-10-14.
+Last updated: 2025-10-21.
 
 ## Version Tracking Guidance
 

--- a/src/driftbuster/catalog.py
+++ b/src/driftbuster/catalog.py
@@ -78,11 +78,12 @@ class DetectionCatalog:
 
 DETECTION_CATALOG = DetectionCatalog(
     version="0.0.1",
-    updated="2025-10-10",
+    updated="2025-10-21",
     notes=(
         "Detection runs in priority order; the first positive match wins.",
         "Heuristics combine filename/extension and lightweight content-signature checks.",
         "Correction: .resx is XML-based resources, not binary.",
+        "StructuredConfigXml metadata now records schema locations, namespace order, and layered transform precedence.",
     ),
     classes=(
         FormatClass(

--- a/src/driftbuster/hunt.py
+++ b/src/driftbuster/hunt.py
@@ -192,6 +192,25 @@ def default_rules() -> Tuple[HuntRule, ...]:
             patterns=(r"\b\d+\.\d+\.\d+(?:\.\d+)?\b",),
         ),
         HuntRule(
+            name="config-appsetting",
+            description="AppSettings key/value pairs inside .config files",
+            token_name="app_setting_value",
+            keywords=("<add", "key=", "value="),
+            patterns=(
+                r"<add\s+[^>]*\bkey\s*=\s*\"[^\"]+\"[^>]*\bvalue\s*=\s*\"[^\"]+\"",
+                r"<add\s+[^>]*\bvalue\s*=\s*\"[^\"]+\"[^>]*\bkey\s*=\s*\"[^\"]+\"",
+            ),
+        ),
+        HuntRule(
+            name="config-connection-string",
+            description="ConnectionString attributes inside .config files",
+            token_name="connection_string",
+            keywords=("connectionstring",),
+            patterns=(
+                r"<add\s+[^>]*\bconnectionString\s*=\s*\"[^\"]+\"",
+            ),
+        ),
+        HuntRule(
             name="install-path",
             description="Suspicious installation or directory paths",
             token_name="install_path",

--- a/src/driftbuster/reporting/html.py
+++ b/src/driftbuster/reporting/html.py
@@ -23,6 +23,8 @@ _HTML_HEADER = """<!doctype html>
     .meta {{ font-size: 0.9rem; color: #ccc; margin-bottom: 1rem; }}
     .warning {{ border: 1px solid #d9534f; padding: 1rem; margin-bottom: 1.5rem; background: #2a0000; }}
     .badge {{ display: inline-block; padding: 0.1rem 0.4rem; border-radius: 0.25rem; font-size: 0.75rem; margin-left: 0.5rem; background: #f6c744; color: #111; }}
+    .highlights {{ margin: 0.5rem 0; }}
+    .highlights .badge {{ margin-left: 0; margin-right: 0.5rem; }}
     .match, .diff-block, .profile-summary, .hunt-section {{ border: 1px solid #333; padding: 1rem; margin-bottom: 1rem; background: #1a1a1a; }}
     .match h3 {{ margin-top: 0; }}
     table {{ width: 100%; border-collapse: collapse; margin-top: 0.5rem; }}
@@ -51,6 +53,22 @@ def _render_match(match: Mapping[str, object], index: int) -> str:
     metadata_table = ""
     if isinstance(metadata, Mapping):
         metadata_table = f"<table>{_format_metadata(metadata)}</table>"
+    highlight_html = ""
+    highlights = match.get("highlights")
+    if isinstance(highlights, Sequence):
+        badges = []
+        for entry in highlights:
+            if isinstance(entry, Mapping):
+                label = entry.get("label")
+                value = entry.get("value")
+                if label and value is not None:
+                    badges.append(
+                        f"<span class=\"badge\">{escape(str(label))}: {escape(str(value))}</span>"
+                    )
+            else:
+                badges.append(f"<span class=\"badge\">{escape(str(entry))}</span>")
+        if badges:
+            highlight_html = "<div class=\"highlights\">" + "".join(badges) + "</div>"
     reasons_list = "".join(f"<li>{escape(str(reason))}</li>" for reason in match.get("reasons", []))
     return (
         "<section class=\"match\">"
@@ -59,6 +77,7 @@ def _render_match(match: Mapping[str, object], index: int) -> str:
         f"<strong>Variant:</strong> {escape(str(match.get('variant')) or '—')}</p>"
         f"<p><strong>Confidence:</strong> {escape(str(match.get('confidence')))}</p>"
         f"<h4>Reasons</h4><ul>{reasons_list or '<li>None provided</li>'}</ul>"
+        f"{highlight_html}"
         f"<h4>Metadata</h4>{metadata_table}"
         "</section>"
     )

--- a/tests/cli/test_profile_cli.py
+++ b/tests/cli/test_profile_cli.py
@@ -60,6 +60,7 @@ def test_profile_cli_hunt_bridge(tmp_path: Path, capsys: pytest.CaptureFixture[s
                         "path": "configs/appsettings.json",
                         "expected_format": "json",
                         "expected_variant": "structured-settings-json",
+                        "metadata": {"expected_dynamic": ["server_name", "connection_string"]},
                     }
                 ],
             }
@@ -67,7 +68,7 @@ def test_profile_cli_hunt_bridge(tmp_path: Path, capsys: pytest.CaptureFixture[s
     }
     hunts_payload = [
         {
-            "rule": {"name": "server-name", "description": "", "token_name": "server"},
+            "rule": {"name": "server-name", "description": "", "token_name": "server_name"},
             "relative_path": "configs/appsettings.json",
             "path": "dummy",
             "line_number": 1,
@@ -92,3 +93,6 @@ def test_profile_cli_hunt_bridge(tmp_path: Path, capsys: pytest.CaptureFixture[s
     assert exit_code == 0
     payload = json.loads(captured.out)
     assert payload["items"][0]["profiles"][0]["profile"] == "prod"
+    profile_info = payload["items"][0]["profiles"][0]
+    assert profile_info["token_match"] is True
+    assert "connection_string" in profile_info["remaining_expected_tokens"]

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -58,3 +58,25 @@ def test_summarise_metadata_serialises_values() -> None:
 
     assert summary["plugin"] == "xml"
     assert summary["metadata"]["catalog_format"] == "xml"
+
+
+def test_summarise_metadata_highlights_namespace() -> None:
+    match = DetectionMatch(
+        plugin_name="xml",
+        format_name="xml",
+        variant="resource-xml",
+        confidence=0.8,
+        reasons=["detected"],
+        metadata={
+            "root_namespace": "urn:test",
+            "schema_locations": [{"namespace": "urn:test", "location": "schema.xsd"}],
+            "schema_no_namespace_location": "local.xsd",
+        },
+    )
+
+    summary = summarise_metadata(match)
+
+    assert "highlights" in summary
+    labels = [entry["label"] for entry in summary["highlights"]]
+    assert "root_namespace" in labels
+    assert any(entry["value"] == "urn:test" for entry in summary["highlights"])

--- a/tests/hunt/test_hunt.py
+++ b/tests/hunt/test_hunt.py
@@ -42,3 +42,26 @@ def test_hunt_path_json_format(tmp_path: Path) -> None:
     entry = payload[0]
     assert entry["rule"]["name"] == "server-name"
     assert entry["relative_path"].endswith("config.txt")
+
+
+def test_config_attribute_hunt_rules(tmp_path: Path) -> None:
+    sample = tmp_path / "web.config"
+    sample.write_text(
+        """
+        <configuration>
+          <appSettings>
+            <add key=\"ApiUrl\" value=\"https://api.example.com/\" />
+          </appSettings>
+          <connectionStrings>
+            <add name=\"Default\" connectionString=\"Server=db01.internal;Database=main;\" />
+          </connectionStrings>
+        </configuration>
+        """,
+        encoding="utf-8",
+    )
+
+    results = hunt_path(sample, rules=default_rules())
+
+    tokens = {hit.rule.token_name for hit in results if hit.rule.token_name}
+    assert "app_setting_value" in tokens
+    assert "connection_string" in tokens

--- a/tests/reporting/test_diff.py
+++ b/tests/reporting/test_diff.py
@@ -1,0 +1,30 @@
+from driftbuster.reporting.diff import canonicalise_xml
+
+
+def test_canonicalise_xml_preserves_namespace_order_and_sorts_attributes() -> None:
+    xml = """
+    <configuration xmlns='urn:config' xmlns:x='urn:x' xmlns:y='urn:y'>
+      <child y:attr='1' x:beta='2' alpha='3'/>
+    </configuration>
+    """
+
+    canonical = canonicalise_xml(xml)
+
+    assert canonical.startswith(
+        "<configuration xmlns=\"urn:config\" xmlns:x=\"urn:x\" xmlns:y=\"urn:y\">"
+    )
+    assert "<child alpha=\"3\" x:beta=\"2\" y:attr=\"1\" />" in canonical
+
+
+def test_canonicalise_xml_trims_schema_attributes_consistently() -> None:
+    xml = """
+    <root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+          xsi:schemaLocation=' urn:test schema.xsd '>
+      <item value='1'/>
+    </root>
+    """
+
+    canonical = canonicalise_xml(xml)
+
+    assert "xsi:schemaLocation=\"urn:test schema.xsd\"" in canonical
+    assert "<item value=\"1\" />" in canonical


### PR DESCRIPTION
## Summary
- capture xsi:schemaLocation and noNamespaceSchemaLocation metadata during XML detection, expose layered transform details, and surface namespace highlights in reporting
- extend the XML canonicaliser to sort attributes while preserving namespace order and add regression coverage for attribute drift
- add .config-specific hunt tokens and enrich profile bridge output with expected token alignment; refresh catalog and support docs for the XML plugin update

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68edcbbf23788323959deef481f57f84