### PR TITLE
Add XML schema provenance and resource metadata

### DIFF
--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -7,7 +7,8 @@ most common file types to the detectors that understand them today.
 
 - **`.config` (web/app/machine)** — handled by the XML plugin. Transform files
   such as `web.Release.config` and assembly sidecars (`*.exe.config`) are
-  surfaced with dedicated variants. Namespaces, XML declarations, and
+  surfaced with dedicated variants. Namespaces, XML declarations, hunt-aligned
+  attribute hints (connection strings, endpoints, feature flags), and
   `schema_locations` provenance metadata are captured automatically.
 - **Manifests (`*.manifest`)** — recognised as `app-manifest-xml` with
   confidence bumps when the assembly namespace is present.

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -7,12 +7,12 @@ most common file types to the detectors that understand them today.
 
 - **`.config` (web/app/machine)** — handled by the XML plugin. Transform files
   such as `web.Release.config` and assembly sidecars (`*.exe.config`) are
-  surfaced with dedicated variants. Namespaces and XML declaration metadata are
-  captured automatically.
+  surfaced with dedicated variants. Namespaces, XML declarations, and
+  `schema_locations` provenance metadata are captured automatically.
 - **Manifests (`*.manifest`)** — recognised as `app-manifest-xml` with
   confidence bumps when the assembly namespace is present.
-- **Resources (`*.resx`)** — classified as `resource-xml` and include resource
-  key metadata in the detection payload.
+- **Resources (`*.resx`)** — classified as `resource-xml` and include captured
+  resource key previews (`resource_keys`) in the detection payload.
 - **XAML (`*.xaml`)** — flagged as `interface-xml` whenever UI namespaces are
   discovered.
 - **JSON (`*.json`, `*.jsonc`)** — the JSON plugin highlights structured

--- a/docs/detection-types.md
+++ b/docs/detection-types.md
@@ -86,6 +86,9 @@ core and XML work stabilise. They are not yet represented in
   payloads even when filenames are ambiguous.
 - ``schema_locations`` metadata now records XSD provenance for XML payloads,
   and `.resx` files include ``resource_keys`` previews for quick auditing.
+- XML detections now attach ``attribute_hints`` metadata so hunt mode can align
+  connection strings, service endpoints, and feature flags with profile
+  expectations.
 - Binary detectors rely on sampling thresholds; large opaque files may need
   increased sample sizes for confident matches.
 - When multiple detectors might claim a file, adjust priorities so the most

--- a/docs/detection-types.md
+++ b/docs/detection-types.md
@@ -84,6 +84,8 @@ core and XML work stabilise. They are not yet represented in
 - XML matches expose ``root_local_name`` and ``root_namespace`` metadata to
   help downstream tools differentiate between manifest, resource, and XAML
   payloads even when filenames are ambiguous.
+- ``schema_locations`` metadata now records XSD provenance for XML payloads,
+  and `.resx` files include ``resource_keys`` previews for quick auditing.
 - Binary detectors rely on sampling thresholds; large opaque files may need
   increased sample sizes for confident matches.
 - When multiple detectors might claim a file, adjust priorities so the most

--- a/docs/detection-types.md
+++ b/docs/detection-types.md
@@ -89,6 +89,9 @@ core and XML work stabilise. They are not yet represented in
 - XML detections now attach ``attribute_hints`` metadata so hunt mode can align
   connection strings, service endpoints, and feature flags with profile
   expectations.
+- MSBuild `.targets`, `.props`, and project payloads emit ``msbuild_*``
+  metadata fields summarising default targets, SDK declarations, and hashed
+  import references to help diff tooling track build graph drift.
 - Binary detectors rely on sampling thresholds; large opaque files may need
   increased sample sizes for confident matches.
 - When multiple detectors might claim a file, adjust priorities so the most

--- a/docs/format-backlog-briefing.md
+++ b/docs/format-backlog-briefing.md
@@ -19,7 +19,7 @@ The backlog remains on HOLD, but we now have a ready-to-run outline covering heu
   - Extensions: `.config`, `.xml`, `.resx`, `.targets`.
   - Patterns: XML declaration, `<configuration>` roots, schemaLocation attributes, namespace URIs.
   - Hunt tokens: attribute drift for connection strings, endpoints, feature flags.
-  - Catalog updates: add schema provenance + namespace confidence weighting fields.
+  - Catalog updates: schema provenance now emitted in ``schema_locations`` metadata; namespace confidence weighting remains on the roadmap.
 - **Sample and testing needs:**
   - Public samples: generic runtime configs, orchestration manifests, open-source application templates.
   - Manual pass: scan well-formed, minified, and malformed XML; confirm metadata tags round-trip.

--- a/docs/format-backlog-briefing.md
+++ b/docs/format-backlog-briefing.md
@@ -6,7 +6,7 @@ The backlog remains on HOLD, but we now have a ready-to-run outline covering heu
 
 | Priority | Format focus | Key rationale | Readiness notes |
 | --- | --- | --- | --- |
-| 1 | XML family | Lock reliable `.config` and schema-backed parsing before downstream adapters inherit inconsistent metadata. | Requires catalog schema provenance fields and attribute hunt tokens. |
+| 1 | XML family | Lock reliable `.config` and schema-backed parsing before downstream adapters inherit inconsistent metadata. | Schema provenance metadata and attribute-aligned hunt tokens shipped; diff tooling remains future follow-up. |
 | 2 | JSON | Harden parsing across `json`, `jsonc`, and structured settings JSON (`appsettings.json`) to stabilise variant tagging for reports. | Needs large-sample validation against new sampling guardrails. |
 | 3 | INI lineage | Unify INI, key/value properties, directive conf, and dotenv handling to prevent duplicate catalog entries. | Requires remediation guidance, secret detection hints, and encoding audit. |
 | 4 | Structured text | Deliver YAML/TOML detectors with tiered confidence to bridge structured/unstructured coverage. | Must define indentation tolerance policy before surfacing matches. |

--- a/docs/format-support.md
+++ b/docs/format-support.md
@@ -8,11 +8,11 @@ aligned.
 
 | Format family            | Variants / focus                                                 | Plugin | Module version | Status       | Notes |
 |--------------------------|------------------------------------------------------------------|--------|----------------|--------------|-------|
-| Structured configuration | `.config` web/app/machine files, build transforms, assembly sidecars | xml    | 0.0.2          | Stabilising  | Transform scope, precedence, and schema provenance metadata now populate automatically. |
-| Generic XML              | Application manifests (`.manifest`), resources (`.resx`), XAML UI | xml    | 0.0.2          | Stabilising  | Namespace logging and schema provenance land in metadata; `.resx` entries expose resource keys. |
+| Structured configuration | `.config` web/app/machine files, build transforms, assembly sidecars | xml    | 0.0.3          | Stabilising  | Transform scope, precedence, schema provenance, and attribute hint metadata now populate automatically. |
+| Generic XML              | Application manifests (`.manifest`), resources (`.resx`), XAML UI | xml    | 0.0.3          | Stabilising  | Namespace logging, schema provenance, `.resx` resource keys, and attribute hints surface alongside hunt-aligned tokens. |
 | JSON                     | Generic JSON, comment-friendly `jsonc`, `appsettings*.json`      | json   | 0.0.1          | Preview      | Large-sample validation and sampling guardrails are still being tuned. |
 
-Last updated: 2025-10-15.
+Last updated: 2025-10-16.
 
 ## Version Tracking Guidance
 

--- a/docs/format-support.md
+++ b/docs/format-support.md
@@ -8,11 +8,11 @@ aligned.
 
 | Format family            | Variants / focus                                                 | Plugin | Module version | Status       | Notes |
 |--------------------------|------------------------------------------------------------------|--------|----------------|--------------|-------|
-| Structured configuration | `.config` web/app/machine files, build transforms, assembly sidecars | xml    | 0.0.1          | Stabilising  | Transform precedence and schema provenance work remain on the roadmap. |
-| Generic XML              | Application manifests (`.manifest`), resources (`.resx`), XAML UI | xml    | 0.0.1          | Stabilising  | Namespace logging lands in metadata; canonical diff tooling still evolving. |
+| Structured configuration | `.config` web/app/machine files, build transforms, assembly sidecars | xml    | 0.0.2          | Stabilising  | Transform scope, precedence, and schema provenance metadata now populate automatically. |
+| Generic XML              | Application manifests (`.manifest`), resources (`.resx`), XAML UI | xml    | 0.0.2          | Stabilising  | Namespace logging and schema provenance land in metadata; `.resx` entries expose resource keys. |
 | JSON                     | Generic JSON, comment-friendly `jsonc`, `appsettings*.json`      | json   | 0.0.1          | Preview      | Large-sample validation and sampling guardrails are still being tuned. |
 
-Last updated: 2025-10-14.
+Last updated: 2025-10-15.
 
 ## Version Tracking Guidance
 

--- a/docs/format-support.md
+++ b/docs/format-support.md
@@ -8,11 +8,11 @@ aligned.
 
 | Format family            | Variants / focus                                                 | Plugin | Module version | Status       | Notes |
 |--------------------------|------------------------------------------------------------------|--------|----------------|--------------|-------|
-| Structured configuration | `.config` web/app/machine files, build transforms, assembly sidecars | xml    | 0.0.3          | Stabilising  | Transform scope, precedence, schema provenance, and attribute hint metadata now populate automatically. |
-| Generic XML              | Application manifests (`.manifest`), resources (`.resx`), XAML UI | xml    | 0.0.3          | Stabilising  | Namespace logging, schema provenance, `.resx` resource keys, and attribute hints surface alongside hunt-aligned tokens. |
+| Structured configuration | `.config` web/app/machine files, build transforms, assembly sidecars | xml    | 0.0.4          | Stabilising  | Transform scope, precedence, schema provenance, attribute hints, and MSBuild metadata now populate automatically. |
+| Generic XML              | Application manifests (`.manifest`), resources (`.resx`), XAML UI | xml    | 0.0.4          | Stabilising  | Namespace logging, schema provenance, `.resx` resource keys, MSBuild project detection, and attribute hints surface alongside hunt-aligned tokens. |
 | JSON                     | Generic JSON, comment-friendly `jsonc`, `appsettings*.json`      | json   | 0.0.1          | Preview      | Large-sample validation and sampling guardrails are still being tuned. |
 
-Last updated: 2025-10-16.
+Last updated: 2025-10-17.
 
 ## Version Tracking Guidance
 

--- a/notes/changelog/formats/xml.md
+++ b/notes/changelog/formats/xml.md
@@ -1,5 +1,13 @@
 # DriftBuster XML Format Changelog
 
+# 0.0.4 — 2025-10-17
+- Recognise MSBuild project, props, and targets payloads with dedicated variants
+  plus metadata covering default targets, SDK declarations, and import hashes.
+- Surface MSBuild-derived reasons (default targets, SDK, imports) and boost
+  confidence for matches enriched with project metadata.
+- Extend XML plugin tests to validate MSBuild metadata hashing and variant
+  classification for both legacy and SDK-style project files.
+
 # 0.0.3 — 2025-10-16
 - Surface ``attribute_hints`` metadata covering connection strings, service
   endpoints, and feature flags with hashed values for drift tracking.

--- a/notes/changelog/formats/xml.md
+++ b/notes/changelog/formats/xml.md
@@ -1,5 +1,13 @@
 # DriftBuster XML Format Changelog
 
+# 0.0.3 — 2025-10-16
+- Surface ``attribute_hints`` metadata covering connection strings, service
+  endpoints, and feature flags with hashed values for drift tracking.
+- Extend XML handling to treat `.targets` payloads as first-class XML and add
+  hunt-aligned reasons for captured attribute hints.
+- Expand hunt rules to include connection-string, service-endpoint, and
+  feature-flag tokens aligned with the new metadata fields.
+
 ## 0.0.2 — 2025-10-15
 - Capture XML schema provenance in ``schema_locations`` metadata and surface
   matching detection reasons.

--- a/notes/changelog/formats/xml.md
+++ b/notes/changelog/formats/xml.md
@@ -1,4 +1,12 @@
 # DriftBuster XML Format Changelog
 
-## 0.0.0
-- Bootstrap entry (no changes tracked yet).
+## 0.0.2 — 2025-10-15
+- Capture XML schema provenance in ``schema_locations`` metadata and surface
+  matching detection reasons.
+- Extract `.resx` resource key previews and expose them via ``resource_keys``
+  along with supporting detection reasons.
+- Bump XML plugin version to ``0.0.2`` to reflect the new metadata contract.
+
+## 0.0.1
+- Initial heuristic implementation covering `.config`, manifest, `.resx`, and
+  XAML payloads with namespace-aware metadata.

--- a/src/driftbuster/hunt.py
+++ b/src/driftbuster/hunt.py
@@ -198,6 +198,31 @@ def default_rules() -> Tuple[HuntRule, ...]:
             keywords=("path", "install"),
             patterns=(r"[A-Za-z]:\\\\[\\w\\-\\.\\s]+", r"/opt/[\w\-\.]+"),
         ),
+        HuntRule(
+            name="connection-string",
+            description="Connection string attribute assignments",
+            token_name="connection_string",
+            patterns=(r"""connectionstring\s*=\s*['"][^'"\n]+['"]""",),
+        ),
+        HuntRule(
+            name="service-endpoint",
+            description="Service endpoint or base address assignments",
+            token_name="service_endpoint",
+            patterns=(
+                r"""<endpoint\b[^>]*\baddress\s*=\s*['"][^'\"]+['"]""",
+                r"""(endpoint|serviceurl|baseaddress)\s*=\s*['"][^'\"]+['"]""",
+                r"""key\s*=\s*['"][^'\"]*(endpoint|serviceurl|baseaddress|address)[^'\"]*['"][^\n]*value\s*=\s*['"][^'\"]+['"]""",
+            ),
+        ),
+        HuntRule(
+            name="feature-flag",
+            description="Feature flag or toggle assignments",
+            token_name="feature_flag",
+            patterns=(
+                r"""key\s*=\s*['"][^'\"]*(feature|flag|toggle)[^'\"]*['"][^\n]*value\s*=\s*['"][^'\"]+['"]""",
+                r"""<feature\b[^>]*\b(enabled|value)\s*=\s*['"][^'\"]+['"]""",
+            ),
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- add schema provenance extraction and .resx resource key capture to the XML plugin metadata
- surface the new metadata in detection reasons, adjust the confidence bonus, and bump the XML plugin to version 0.0.2
- document the updated capabilities in the XML format guides and changelog with new unit tests for schema/resource extraction

## Testing
- pytest tests/formats/test_xml_plugin.py

------
https://chatgpt.com/codex/tasks/task_e_68ee1e5c5b6c83238c97c785b171f325