### PR TITLE
Add INI format plugin with detection tests

### DIFF
--- a/src/driftbuster/formats/__init__.py
+++ b/src/driftbuster/formats/__init__.py
@@ -11,6 +11,7 @@ from .registry import (
 # Ensure built-in plugins register on import.
 from . import xml  # noqa: F401
 from . import json as _json_plugin  # noqa: F401
+from . import ini as _ini_plugin  # noqa: F401
 
 __all__ = [
     "FormatPlugin",

--- a/src/driftbuster/formats/ini.py
+++ b/src/driftbuster/formats/ini.py
@@ -1,0 +1,117 @@
+"""INI detection heuristics for configuration-style payloads."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .registry import register
+from ..core.types import DetectionMatch
+
+
+_SECTION_PATTERN = re.compile(r"^\s*\[([^\]\n]+)\]\s*$", re.MULTILINE)
+_KEY_VALUE_PATTERN = re.compile(r"^\s*([A-Za-z0-9_.\-]+)\s*=\s*([^\n]*)$", re.MULTILINE)
+_COMMENT_PATTERN = re.compile(r"^\s*[;#]", re.MULTILINE)
+_INI_EXTENSIONS = {".ini", ".cfg", ".cnf"}
+_MAX_SECTION_SNAPSHOT = 10
+
+
+@dataclass
+class IniPlugin:
+    """Detect classic INI-style configuration files."""
+
+    name: str = "ini"
+    priority: int = 170
+    version: str = "0.0.1"
+
+    def detect(self, path: Path, sample: bytes, text: Optional[str]) -> Optional[DetectionMatch]:
+        if text is None:
+            return None
+
+        lower_name = path.name.lower()
+        extension = path.suffix.lower()
+
+        reasons: List[str] = []
+        metadata: Dict[str, object] = {}
+
+        sections = [section.strip() for section in _SECTION_PATTERN.findall(text) if section.strip()]
+        if sections:
+            reasons.append("Found [section] headers indicative of INI structure")
+            unique_sections = []
+            seen = set()
+            for section in sections:
+                key = section.lower()
+                if key in seen:
+                    continue
+                seen.add(key)
+                unique_sections.append(section)
+            metadata["sections"] = unique_sections[:_MAX_SECTION_SNAPSHOT]
+            metadata["section_count"] = len(unique_sections)
+
+        key_pairs = _KEY_VALUE_PATTERN.findall(text)
+        if key_pairs:
+            reasons.append("Detected key=value assignments typical of INI configuration")
+            metadata["key_value_pairs"] = len(key_pairs)
+
+        if not (sections and key_pairs):
+            return None
+
+        if extension in _INI_EXTENSIONS:
+            reasons.append(f"File extension {extension} suggests INI content")
+        elif lower_name.endswith(".ini"):
+            reasons.append("Filename suffix .ini suggests INI content")
+
+        if lower_name == "desktop.ini":
+            reasons.append("Filename desktop.ini is commonly produced by Windows shell metadata")
+            metadata["profile_hint"] = "desktop.ini"
+
+        comment_signal = bool(_COMMENT_PATTERN.search(text))
+        if comment_signal:
+            reasons.append("Detected ; or # comment markers used by INI files")
+
+        signals = 0
+        if sections:
+            signals += 1
+        if key_pairs:
+            signals += 1
+        if extension in _INI_EXTENSIONS or lower_name.endswith(".ini"):
+            signals += 1
+        if lower_name == "desktop.ini":
+            signals += 1
+        if comment_signal:
+            signals += 1
+
+        if signals < 2:
+            return None
+
+        confidence = 0.5
+        if sections:
+            confidence += 0.15
+        if key_pairs:
+            confidence += 0.15
+        if extension in _INI_EXTENSIONS or lower_name.endswith(".ini"):
+            confidence += 0.1
+        if lower_name == "desktop.ini":
+            confidence += 0.05
+        if metadata.get("key_value_pairs", 0) >= 5:
+            confidence += 0.05
+
+        confidence = min(confidence, 0.92)
+
+        variant: Optional[str] = None
+        if lower_name == "desktop.ini":
+            variant = "desktop-ini"
+
+        return DetectionMatch(
+            plugin_name=self.name,
+            format_name="ini",
+            variant=variant,
+            confidence=confidence,
+            reasons=reasons,
+            metadata=metadata or None,
+        )
+
+
+register(IniPlugin())

--- a/tests/formats/test_ini_plugin.py
+++ b/tests/formats/test_ini_plugin.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from driftbuster.core.types import DetectionMatch
+from driftbuster.formats.ini import IniPlugin
+
+
+def _detect(plugin: IniPlugin, filename: str, content: str) -> DetectionMatch | None:
+    path = Path(filename)
+    data = content.encode("utf-8")
+    return plugin.detect(path, data, content)
+
+
+def test_ini_plugin_detects_sections_and_keys() -> None:
+    plugin = IniPlugin()
+    match = _detect(
+        plugin,
+        "settings.ini",
+        """
+        [general]
+        enabled = true
+        threshold = 10
+        [logging]
+        level = info
+        """.strip(),
+    )
+
+    assert match is not None
+    assert match.format_name == "ini"
+    assert match.variant is None
+    assert match.metadata is not None
+    assert match.metadata["section_count"] == 2
+    assert match.metadata["key_value_pairs"] >= 3
+
+
+def test_ini_plugin_detects_desktop_ini_variant() -> None:
+    plugin = IniPlugin()
+    match = _detect(
+        plugin,
+        "desktop.ini",
+        """
+        [.ShellClassInfo]
+        IconResource=shell32.dll,3
+        ConfirmFileOp=0
+        """.strip(),
+    )
+
+    assert match is not None
+    assert match.variant == "desktop-ini"
+    assert match.metadata is not None
+    assert ".ShellClassInfo" in match.metadata.get("sections", [])
+
+
+def test_ini_plugin_rejects_plain_text() -> None:
+    plugin = IniPlugin()
+    match = _detect(plugin, "notes.txt", "This is just a paragraph of text without configuration cues.")
+
+    assert match is None


### PR DESCRIPTION
## Summary
- add an IniPlugin that detects INI configuration files and captures section metadata
- register the INI plugin alongside the existing JSON and XML detectors
- cover positive and negative detection scenarios with targeted unit tests

## Testing
- pytest tests/formats/test_ini_plugin.py

------
https://chatgpt.com/codex/tasks/task_e_68eeeff827e48323b3c7898280514a81