### PR TITLE
Refine INI format heuristics for broader config coverage

### DIFF
--- a/src/driftbuster/formats/ini.py
+++ b/src/driftbuster/formats/ini.py
@@ -12,9 +12,24 @@ from ..core.types import DetectionMatch
 
 
 _SECTION_PATTERN = re.compile(r"^\s*\[([^\]\n]+)\]\s*$", re.MULTILINE)
-_KEY_VALUE_PATTERN = re.compile(r"^\s*([A-Za-z0-9_.\-]+)\s*=\s*([^\n]*)$", re.MULTILINE)
-_COMMENT_PATTERN = re.compile(r"^\s*[;#]", re.MULTILINE)
-_INI_EXTENSIONS = {".ini", ".cfg", ".cnf"}
+_KEY_VALUE_PATTERN = re.compile(
+    r"^\s*(?P<export>export\s+)?(?P<key>[A-Za-z0-9_.\-]+)\s*(?:=|:)\s*(?P<value>.*?)(?P<continued>\\\s*)?$",
+    re.MULTILINE,
+)
+_COMMENT_PATTERN = re.compile(r"^\s*[;#!]", re.MULTILINE)
+_INI_EXTENSIONS = {".ini", ".cfg", ".cnf", ".conf", ".properties", ".env"}
+_DOTENV_FILENAMES = {
+    ".env",
+    ".env.local",
+    ".env.development",
+    ".env.production",
+    ".env.test",
+    ".env.example",
+    ".env.sample",
+}
+_DIRECTIVE_PATTERN = re.compile(
+    r"^\s*(?:include|loadmodule|setenv|option|alias)\b", re.IGNORECASE | re.MULTILINE
+)
 _MAX_SECTION_SNAPSHOT = 10
 
 
@@ -50,35 +65,73 @@ class IniPlugin:
             metadata["sections"] = unique_sections[:_MAX_SECTION_SNAPSHOT]
             metadata["section_count"] = len(unique_sections)
 
-        key_pairs = _KEY_VALUE_PATTERN.findall(text)
-        if key_pairs:
-            reasons.append("Detected key=value assignments typical of INI configuration")
-            metadata["key_value_pairs"] = len(key_pairs)
+        key_matches = list(_KEY_VALUE_PATTERN.finditer(text))
+        key_pair_count = len(key_matches)
+        if key_pair_count:
+            reasons.append("Detected key/value assignments typical of INI-style configuration")
+            metadata["key_value_pairs"] = key_pair_count
 
-        if not (sections and key_pairs):
-            return None
+        lines = text.splitlines()
+        non_empty_lines = [line for line in lines if line.strip()]
+        comment_lines = [line for line in non_empty_lines if _COMMENT_PATTERN.match(line)]
+        directive_lines = [line for line in non_empty_lines if _DIRECTIVE_PATTERN.match(line)]
+
+        continuation_lines = sum(1 for match in key_matches if match.group("continued"))
+        export_lines = sum(1 for match in key_matches if match.group("export"))
+        if export_lines:
+            metadata["export_assignments"] = export_lines
+            reasons.append("Detected environment-style export assignments")
+
+        if continuation_lines:
+            metadata["continuations"] = continuation_lines
+
+        directive_signal = bool(directive_lines)
+        if directive_signal:
+            metadata["directive_line_count"] = min(len(directive_lines), 10)
+            reasons.append("Found directive keywords common in INI/conf files")
 
         if extension in _INI_EXTENSIONS:
-            reasons.append(f"File extension {extension} suggests INI content")
+            reasons.append(f"File extension {extension} suggests INI-like configuration")
         elif lower_name.endswith(".ini"):
             reasons.append("Filename suffix .ini suggests INI content")
+
+        dotenv_hint = lower_name in _DOTENV_FILENAMES
+        if dotenv_hint:
+            reasons.append("Filename is a known dotenv-style configuration")
 
         if lower_name == "desktop.ini":
             reasons.append("Filename desktop.ini is commonly produced by Windows shell metadata")
             metadata["profile_hint"] = "desktop.ini"
 
-        comment_signal = bool(_COMMENT_PATTERN.search(text))
+        comment_signal = bool(comment_lines)
         if comment_signal:
-            reasons.append("Detected ; or # comment markers used by INI files")
+            reasons.append("Detected comment markers (;, #, !) used by INI variants")
+
+        effective_lines = max(len(non_empty_lines) - len(comment_lines), 1)
+        key_density = key_pair_count / effective_lines
+        metadata["key_density"] = round(key_density, 3)
+
+        key_density_strong = key_density >= 0.3 or key_pair_count >= 4
+        extension_hint = extension in _INI_EXTENSIONS or lower_name.endswith(".ini")
+
+        if not (key_pair_count or directive_signal):
+            return None
+
+        if not sections and not key_density_strong and not directive_signal and not extension_hint:
+            return None
 
         signals = 0
         if sections:
             signals += 1
-        if key_pairs:
+        if key_pair_count:
             signals += 1
-        if extension in _INI_EXTENSIONS or lower_name.endswith(".ini"):
+        if key_density_strong:
             signals += 1
-        if lower_name == "desktop.ini":
+        if extension_hint or dotenv_hint:
+            signals += 1
+        if directive_signal:
+            signals += 1
+        if export_lines:
             signals += 1
         if comment_signal:
             signals += 1
@@ -86,19 +139,24 @@ class IniPlugin:
         if signals < 2:
             return None
 
-        confidence = 0.5
+        confidence = 0.4
+        confidence += min(key_density, 0.6) * 0.25
         if sections:
-            confidence += 0.15
-        if key_pairs:
-            confidence += 0.15
-        if extension in _INI_EXTENSIONS or lower_name.endswith(".ini"):
+            confidence += 0.2
+        if extension_hint:
             confidence += 0.1
-        if lower_name == "desktop.ini":
+        if dotenv_hint:
             confidence += 0.05
-        if metadata.get("key_value_pairs", 0) >= 5:
+        if directive_signal:
+            confidence += 0.1
+        if export_lines:
+            confidence += 0.08
+        if comment_signal:
+            confidence += 0.05
+        if key_pair_count >= 6:
             confidence += 0.05
 
-        confidence = min(confidence, 0.92)
+        confidence = min(confidence, 0.95)
 
         variant: Optional[str] = None
         if lower_name == "desktop.ini":

--- a/tests/formats/test_ini_plugin.py
+++ b/tests/formats/test_ini_plugin.py
@@ -57,3 +57,17 @@ def test_ini_plugin_rejects_plain_text() -> None:
     match = _detect(plugin, "notes.txt", "This is just a paragraph of text without configuration cues.")
 
     assert match is None
+
+
+def test_ini_plugin_rejects_yaml_with_colons() -> None:
+    plugin = IniPlugin()
+    match = _detect(
+        plugin,
+        "config.yaml",
+        """
+        foo: bar
+        bar: baz
+        """.strip(),
+    )
+
+    assert match is None


### PR DESCRIPTION
## Summary
- expand INI key/value parsing to accept export-prefixed assignments, : separators, and continuation lines while recognizing additional comment markers
- broaden filename and directive heuristics so dotenv and conf-style payloads contribute to detection without requiring section headers
- rebalance confidence scoring to weight sections, directives, extensions, and export density independently

## Testing
- pytest tests/formats/test_ini_plugin.py

------
https://chatgpt.com/codex/tasks/task_e_68eef7921e3c832381eff6a87f1c380e