### PR TITLE
Resolve open automation rig issues and SDK security update

### DIFF
--- a/docs/coverage-golden-standard.md
+++ b/docs/coverage-golden-standard.md
@@ -8,7 +8,8 @@ documentation.
 
 - Required thresholds:
   - Python (engine/detectors/reporting): ≥ 90% line coverage on `src/`.
-  - .NET (GUI + backend): ≥ 90% total line coverage (coverlet). 
+  - .NET (GUI + backend): ≥ 90% scoped line coverage on production `.cs`
+    files (exclude test projects and `obj/` generated files).
   - New/changed modules must land with ≥ 90% per-file coverage unless
     platform-only code is explicitly excluded (e.g., Windows registry P/Invoke).
 
@@ -39,8 +40,13 @@ documentation.
   python -m scripts.coverage_report
   ```
 
-  The script prints Python percentage, .NET percentage, and the top
-  under‑covered GUI classes to focus further tests.
+  The script prints Python percentage, raw Cobertura .NET percentage, scoped
+  production `.cs` .NET percentage, and the top under‑covered files/classes.
+  To enforce the scoped .NET threshold:
+
+  ```sh
+  python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold
+  ```
 
 ## INI Coverage Baseline
 - **Variants:** Must classify `sectioned-ini`, `sectionless-ini`, `desktop-ini`,
@@ -83,7 +89,8 @@ documentation.
 Required command checks (enforced locally):
 
 - Python: `coverage run --source=src/driftbuster -m pytest -q && coverage report --fail-under=90`
-- .NET: `dotnet test -p:Threshold=90 -p:ThresholdType=line -p:ThresholdStat=total`
+- .NET: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj --collect:"XPlat Code Coverage" --results-directory artifacts/coverage-dotnet`
+- .NET threshold enforcement: `python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold`
 
 ## Test Coverage Map
 

--- a/docs/coverage-golden-standard.md
+++ b/docs/coverage-golden-standard.md
@@ -8,8 +8,10 @@ documentation.
 
 - Required thresholds:
   - Python (engine/detectors/reporting): ≥ 90% line coverage on `src/`.
-  - .NET (GUI + backend): ≥ 90% scoped line coverage on production `.cs`
-    files (exclude test projects and `obj/` generated files).
+  - .NET (GUI + backend): ≥ 90% line coverage on changed production `.cs`
+    executable lines versus the target base branch (default `origin/main`).
+    Repo-wide scoped production `.cs` coverage is still reported for backlog
+    visibility.
   - New/changed modules must land with ≥ 90% per-file coverage unless
     platform-only code is explicitly excluded (e.g., Windows registry P/Invoke).
 
@@ -41,11 +43,12 @@ documentation.
   ```
 
   The script prints Python percentage, raw Cobertura .NET percentage, scoped
-  production `.cs` .NET percentage, and the top under‑covered files/classes.
-  To enforce the scoped .NET threshold:
+  production `.cs` .NET percentage, changed-line `.cs` .NET percentage (when a
+  diff base is supplied), and the top under‑covered files/classes.
+  To enforce the changed-line .NET threshold:
 
   ```sh
-  python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold
+  python -m scripts.coverage_report --dotnet-threshold 90 --dotnet-diff-base origin/main --dotnet-enforce-scope changed --enforce-dotnet-threshold
   ```
 
 ## INI Coverage Baseline
@@ -90,7 +93,7 @@ Required command checks (enforced locally):
 
 - Python: `coverage run --source=src/driftbuster -m pytest -q && coverage report --fail-under=90`
 - .NET: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj --collect:"XPlat Code Coverage" --results-directory artifacts/coverage-dotnet`
-- .NET threshold enforcement: `python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold`
+- .NET threshold enforcement: `python -m scripts.coverage_report --dotnet-threshold 90 --dotnet-diff-base origin/main --dotnet-enforce-scope changed --enforce-dotnet-threshold`
 
 ## Test Coverage Map
 

--- a/docs/reviewer-checklist.md
+++ b/docs/reviewer-checklist.md
@@ -20,7 +20,7 @@ ruff(formats/registry_live): ruff check src/driftbuster/formats/registry_live
 ruff(registry helpers): ruff check src/driftbuster/registry
 coverage(py): coverage run --source=src/driftbuster -m pytest -q && coverage report --fail-under=90
 coverage(net): dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj --collect:"XPlat Code Coverage" --results-directory artifacts/coverage-dotnet
-coverage(net-enforce): python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold
+coverage(net-enforce): python -m scripts.coverage_report --dotnet-threshold 90 --dotnet-diff-base origin/main --dotnet-enforce-scope changed --enforce-dotnet-threshold
 ```
 
 Check off each line once you've read the output and confirmed no surprises.

--- a/docs/reviewer-checklist.md
+++ b/docs/reviewer-checklist.md
@@ -19,7 +19,8 @@ ruff(core): ruff check src/driftbuster/core
 ruff(formats/registry_live): ruff check src/driftbuster/formats/registry_live
 ruff(registry helpers): ruff check src/driftbuster/registry
 coverage(py): coverage run --source=src/driftbuster -m pytest -q && coverage report --fail-under=90
-coverage(net): dotnet test -p:Threshold=90 -p:ThresholdType=line -p:ThresholdStat=total gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj
+coverage(net): dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj --collect:"XPlat Code Coverage" --results-directory artifacts/coverage-dotnet
+coverage(net-enforce): python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold
 ```
 
 Check off each line once you've read the output and confirmed no surprises.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -59,7 +59,8 @@ minimise output or skip rebuilds during local iteration.
     per-viewmodel coverage and ensure the heavy UI surfaces (catalog,
     drilldown, multi-server orchestration) stay at or above the 90% line-baseline.
 - Repo‑wide summary: `python -m scripts.coverage_report`
-  - Prints Python %, .NET %, and the most under‑covered GUI classes.
+  - Prints Python %, raw .NET Cobertura %, scoped production `.cs` .NET %, and the most under‑covered files/classes.
+  - Enforce .NET scoped threshold: `python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold`
 
 ### Review flags and profile ignores
 - Plugins may mark oddities with `metadata.needs_review` and `review_reasons`.
@@ -70,7 +71,8 @@ minimise output or skip rebuilds during local iteration.
 Local guardrails:
 
 - Python threshold: `coverage report --fail-under=90`
-- .NET threshold (coverlet): `dotnet test -p:Threshold=90 -p:ThresholdType=line -p:ThresholdStat=total`
+- .NET coverage collection: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj --collect="XPlat Code Coverage" --results-directory artifacts/coverage-dotnet`
+- .NET threshold enforcement: `python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold`
 
 Shortcut: run `scripts/verify_coverage.sh` (POSIX shells) or `python -m scripts.verify_coverage` for the cross-platform equivalent to execute both suites with thresholds and print the combined summary.
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -5,7 +5,8 @@ PowerShell/GUI backend library, and Avalonia viewmodels. Manual validation
 continues to play a role for vendor fixtures and pre-HOLD reporting flows.
 
 Policy: Maintain ≥ 90% line coverage across Python source (under `src/`) and
-≥ 90% total line coverage for the .NET surface. Treat this as a hard baseline
+≥ 90% changed-line coverage for production .NET `.cs` executable lines (versus
+the target base branch, default `origin/main`). Treat this as a hard baseline
 for new and modified components.
 
 ## Automated test suite
@@ -59,8 +60,8 @@ minimise output or skip rebuilds during local iteration.
     per-viewmodel coverage and ensure the heavy UI surfaces (catalog,
     drilldown, multi-server orchestration) stay at or above the 90% line-baseline.
 - Repo‑wide summary: `python -m scripts.coverage_report`
-  - Prints Python %, raw .NET Cobertura %, scoped production `.cs` .NET %, and the most under‑covered files/classes.
-  - Enforce .NET scoped threshold: `python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold`
+  - Prints Python %, raw .NET Cobertura %, scoped production `.cs` .NET %, changed-line production `.cs` .NET % (when `--dotnet-diff-base` is provided), and the most under‑covered files/classes.
+  - Enforce .NET changed-line threshold: `python -m scripts.coverage_report --dotnet-threshold 90 --dotnet-diff-base origin/main --dotnet-enforce-scope changed --enforce-dotnet-threshold`
 
 ### Review flags and profile ignores
 - Plugins may mark oddities with `metadata.needs_review` and `review_reasons`.
@@ -72,7 +73,7 @@ Local guardrails:
 
 - Python threshold: `coverage report --fail-under=90`
 - .NET coverage collection: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj --collect="XPlat Code Coverage" --results-directory artifacts/coverage-dotnet`
-- .NET threshold enforcement: `python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold`
+- .NET threshold enforcement: `python -m scripts.coverage_report --dotnet-threshold 90 --dotnet-diff-base origin/main --dotnet-enforce-scope changed --enforce-dotnet-threshold`
 
 Shortcut: run `scripts/verify_coverage.sh` (POSIX shells) or `python -m scripts.verify_coverage` for the cross-platform equivalent to execute both suites with thresholds and print the combined summary.
 

--- a/docs/tools/vm-testing.md
+++ b/docs/tools/vm-testing.md
@@ -1,0 +1,186 @@
+# VM Testing Guide
+
+How to deploy and test DriftBuster GUI builds on the lab VM.
+
+## VM Details
+
+| Property | Value |
+|----------|-------|
+| Hostname | DriftBuster01 |
+| OS | Windows Server 2022 Desktop Experience |
+| IP | 10.1.0.10 |
+| Host IP | 10.1.0.1 |
+| Remote exec | `vm-exec.sh` from WasItTested repo |
+
+## Prerequisites
+
+- `/staging/WasItTested/cmdb/cmdb.db` — CMDB with guest records
+- `vm-exec.sh` — WinRM/SSH/agent transport script at `/github/repos/WasItTested/scripts/vm-exec.sh`
+- HTTP server on host for file transfer (SCP not configured — no SSH key auth on VM)
+
+## .NET Runtimes on VM
+
+Install the WindowsDesktop runtime to match the user's target environment:
+
+```bash
+# Install .NET 10.0.1 (matches user's Win11 laptop)
+vm-exec.sh DriftBuster01 --ps "
+  Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile C:\dotnet-install.ps1 -UseBasicParsing
+  C:\dotnet-install.ps1 -Channel 10.0 -Version 10.0.1 -Runtime dotnet -InstallDir 'C:\Program Files\dotnet'
+  C:\dotnet-install.ps1 -Channel 10.0 -Version 10.0.1 -Runtime windowsdesktop -InstallDir 'C:\Program Files\dotnet'
+"
+
+# Verify
+vm-exec.sh DriftBuster01 --ps "dotnet --list-runtimes"
+```
+
+## Build Types
+
+### Framework-Dependent (small, requires .NET on target)
+
+```bash
+dotnet publish gui/DriftBuster.Gui/DriftBuster.Gui.csproj \
+  -c Release -r win-x64 --self-contained false \
+  -o build/artifacts/gui/win-x64-fd -p:PublishSingleFile=false
+```
+
+- ~11 MB compressed, 44 files
+- Requires matching .NET runtime on target
+- **Known issue on .NET 10.0.1**: `$Default` font crash — fixed with try/catch fallback in `App.axaml.cs`
+
+### Self-Contained (large, standalone)
+
+```bash
+python scripts/release_build.py --skip-tests --runtime win-x64 --no-installer
+```
+
+- ~28 MB, bundles .NET runtime
+- Works regardless of installed .NET version
+- Output: `build/artifacts/gui/win-x64/`
+
+## Deploy and Test Workflow
+
+### 1. Package the build
+
+```bash
+cd build/artifacts/gui/win-x64-fd   # or win-x64 for self-contained
+tar czf /tmp/driftbuster-build.tar.gz .
+```
+
+### 2. Serve via HTTP (SCP unavailable)
+
+```bash
+cd /tmp && nohup python3 -m http.server 8899 --bind 0.0.0.0 > /tmp/httpserver.log 2>&1 &
+```
+
+### 3. Deploy to VM
+
+```bash
+vm-exec.sh DriftBuster01 --ps "
+  Remove-Item -Recurse -Force C:\DriftBuster-FD -ErrorAction SilentlyContinue
+  New-Item -ItemType Directory -Force C:\DriftBuster-FD | Out-Null
+  Invoke-WebRequest -Uri 'http://10.1.0.1:8899/driftbuster-build.tar.gz' \
+    -OutFile C:\DriftBuster-FD\build.tar.gz -UseBasicParsing
+  cd C:\DriftBuster-FD; tar xzf build.tar.gz; Remove-Item build.tar.gz
+"
+```
+
+### 4. Pre-launch PID check
+
+```bash
+vm-exec.sh DriftBuster01 --ps "
+  Get-Process | Where-Object { \$_.ProcessName -like '*DriftBuster*' } |
+    Select-Object Id, ProcessName, StartTime | Format-Table -AutoSize
+"
+```
+
+### 5. Launch and verify
+
+```bash
+# Option A: Background launch + polling
+vm-exec.sh DriftBuster01 --ps "
+  Start-Process -FilePath 'C:\DriftBuster-FD\DriftBuster.Gui.exe' -WorkingDirectory 'C:\DriftBuster-FD'
+  Start-Sleep -Seconds 8
+  Get-Process | Where-Object { \$_.ProcessName -like '*DriftBuster*' } |
+    Select-Object Id, ProcessName, StartTime, @{N='MB';E={[math]::Round(\$_.WorkingSet64/1MB,1)}} |
+    Format-Table -AutoSize
+"
+
+# Option B: Captured output (blocks until exit or timeout)
+vm-exec.sh DriftBuster01 --ps "
+  \$pinfo = New-Object System.Diagnostics.ProcessStartInfo
+  \$pinfo.FileName = 'C:\DriftBuster-FD\DriftBuster.Gui.exe'
+  \$pinfo.WorkingDirectory = 'C:\DriftBuster-FD'
+  \$pinfo.RedirectStandardOutput = \$true
+  \$pinfo.RedirectStandardError = \$true
+  \$pinfo.UseShellExecute = \$false
+  \$pinfo.CreateNoWindow = \$true
+  \$proc = New-Object System.Diagnostics.Process
+  \$proc.StartInfo = \$pinfo
+  \$proc.Start() | Out-Null
+  \$exited = \$proc.WaitForExit(15000)
+  if (\$exited) {
+    Write-Output \"EXITED code=\$(\$proc.ExitCode)\"
+    Write-Output \$proc.StandardError.ReadToEnd()
+  } else {
+    Write-Output 'SUCCESS: Still running after 15s'
+  }
+"
+```
+
+### 6. Post-test cleanup
+
+```bash
+vm-exec.sh DriftBuster01 --ps "
+  Get-Process | Where-Object { \$_.ProcessName -like '*DriftBuster*' } |
+    ForEach-Object { Stop-Process -Id \$_.Id -Force }
+  Start-Sleep -Seconds 2
+  Get-Process | Where-Object { \$_.ProcessName -like '*DriftBuster*' } |
+    Format-Table Id, ProcessName -AutoSize
+"
+
+# Kill HTTP server on host
+kill $(lsof -ti:8899) 2>/dev/null
+```
+
+## Stray PID Discipline
+
+Always check for stray processes **before** and **after** testing. The GUI can leave orphan processes on crash:
+
+```bash
+# Before
+vm-exec.sh DriftBuster01 --ps "Get-Process *DriftBuster* -ErrorAction SilentlyContinue"
+
+# After (force kill if needed)
+vm-exec.sh DriftBuster01 --ps "
+  Stop-Process -Name DriftBuster* -Force -ErrorAction SilentlyContinue
+  Start-Sleep -Seconds 2
+  Get-Process *DriftBuster* -ErrorAction SilentlyContinue
+"
+```
+
+## Troubleshooting
+
+### `$Default (key: )` font crash
+
+Affects framework-dependent builds on .NET 10.0.1. `FontFamily("Inter")` has no URI key, so FontManager only searches SystemFonts. Fixed in `App.axaml.cs` by catching the `InvalidOperationException` and retargeting the default to `FontFamily("fonts:Inter#Inter")` which explicitly hits the InterFontCollection.
+
+**Diagnostic approach**: Add `Console.Error.WriteLine` calls in the catch block to dump:
+- `FontManager.Current` field state (via reflection)
+- Per-collection `TryGetGlyphTypeface("Inter", ...)` results
+- System font probes (`Segoe UI`, `Arial`)
+
+### vm-exec.sh single-quote issue
+
+PowerShell commands containing single quotes break the `--agent` transport (Python `json.dumps` fails). Use `--ps` transport (WinRM) and avoid bare single quotes in commands. Use `--winrm` for manual string escaping.
+
+### HTTP server dying between commands
+
+Use `nohup` to keep it alive across separate terminal commands:
+```bash
+cd /tmp && nohup python3 -m http.server 8899 --bind 0.0.0.0 > /tmp/httpserver.log 2>&1 &
+```
+
+### No display on headless launch
+
+`CreateNoWindow = $true` runs the GUI in background (no interactive session). Processes still launch and run, but the window won't be visible to a console-only session. For visibility testing, use RDP.

--- a/docs/windows-gui-guide.md
+++ b/docs/windows-gui-guide.md
@@ -253,8 +253,9 @@ The captures above follow the asset naming convention documented in `docs/ux-ref
 - **Failure triage:** If either command fails, inspect `artifacts/logs/fontmanager-regression.txt` for the captured stack trace and rerun `Program.EnsureHeadless` instrumentation to verify the proxy registered its aliases.
 - Run targeted suites via tmux: `tmux new -d -s codexcli-ui 'cd /github/repos/DriftBuster && dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj --filter "FullyQualifiedName~DiffViewTests"'`.
 - Full coverage expectations:
-  - Debug: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj -p:Threshold=90 -p:ThresholdType=line -p:ThresholdStat=total`
-  - Release: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj -c Release -p:Threshold=90 -p:ThresholdType=line -p:ThresholdStat=total`
+  - Debug collect: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj --collect:"XPlat Code Coverage" --results-directory artifacts/coverage-dotnet`
+  - Release collect: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj -c Release --collect:"XPlat Code Coverage" --results-directory artifacts/coverage-dotnet`
+  - Enforce scoped .NET threshold: `python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold`
   - XAML compilation gate: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj -p:EnableAvaloniaXamlCompilation=true`
 - Diagnostic harness: set `AVALONIA_INSPECT=1` and run `--filter FullyQualifiedName=DriftBuster.Gui.Tests.Ui.AvaloniaSetupInspection.LogSetupState` to capture resource/style registration in `artifacts/codexcli-inspect.log`.
 

--- a/docs/windows-gui-guide.md
+++ b/docs/windows-gui-guide.md
@@ -255,7 +255,7 @@ The captures above follow the asset naming convention documented in `docs/ux-ref
 - Full coverage expectations:
   - Debug collect: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj --collect:"XPlat Code Coverage" --results-directory artifacts/coverage-dotnet`
   - Release collect: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj -c Release --collect:"XPlat Code Coverage" --results-directory artifacts/coverage-dotnet`
-  - Enforce scoped .NET threshold: `python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold`
+  - Enforce changed-line .NET threshold: `python -m scripts.coverage_report --dotnet-threshold 90 --dotnet-diff-base origin/main --dotnet-enforce-scope changed --enforce-dotnet-threshold`
   - XAML compilation gate: `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj -p:EnableAvaloniaXamlCompilation=true`
 - Diagnostic harness: set `AVALONIA_INSPECT=1` and run `--filter FullyQualifiedName=DriftBuster.Gui.Tests.Ui.AvaloniaSetupInspection.LogSetupState` to capture resource/style registration in `artifacts/codexcli-inspect.log`.
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.101",
+    "version": "10.0.103",
     "rollForward": "latestPatch"
   }
 }

--- a/gui/DriftBuster.Gui.Tests/Backend/DriftbusterPathsTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Backend/DriftbusterPathsTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+
+using AwesomeAssertions;
+
+using DriftBuster.Backend;
+using DriftBuster.Gui.Tests;
+
+namespace DriftBuster.Gui.Tests.Backend;
+
+[Collection(EnvironmentVariablesCollection.Name)]
+public sealed class DriftbusterPathsTests : IDisposable
+{
+    private readonly string? _originalDataRoot;
+    private readonly string? _originalXdgDataHome;
+    private readonly string? _originalHome;
+    private readonly string _tempRoot;
+
+    public DriftbusterPathsTests()
+    {
+        _originalDataRoot = Environment.GetEnvironmentVariable("DRIFTBUSTER_DATA_ROOT");
+        _originalXdgDataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+        _originalHome = Environment.GetEnvironmentVariable("HOME");
+        _tempRoot = Path.Combine(Path.GetTempPath(), "driftbuster-path-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("DRIFTBUSTER_DATA_ROOT", _originalDataRoot);
+        Environment.SetEnvironmentVariable("XDG_DATA_HOME", _originalXdgDataHome);
+        Environment.SetEnvironmentVariable("HOME", _originalHome);
+
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetDataRoot_prefers_environment_override()
+    {
+        var overridePath = Path.Combine(_tempRoot, "override-data-root");
+        Environment.SetEnvironmentVariable("DRIFTBUSTER_DATA_ROOT", $"  {overridePath}  ");
+
+        var resolved = DriftbusterPaths.GetDataRoot();
+
+        resolved.Should().Be(Path.GetFullPath(overridePath));
+        Directory.Exists(resolved).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetDataRoot_expands_tilde_in_environment_override()
+    {
+        Environment.SetEnvironmentVariable("DRIFTBUSTER_DATA_ROOT", "~/driftbuster-tilde-test");
+
+        var resolved = DriftbusterPaths.GetDataRoot();
+        try
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+
+            resolved.StartsWith(home, StringComparison.OrdinalIgnoreCase).Should().BeTrue();
+            resolved.Should().Contain("driftbuster-tilde-test");
+        }
+        finally
+        {
+            if (Directory.Exists(resolved))
+            {
+                Directory.Delete(resolved, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void GetDataRoot_uses_xdg_data_home_when_override_missing()
+    {
+        Environment.SetEnvironmentVariable("DRIFTBUSTER_DATA_ROOT", null);
+        var xdgRoot = Path.Combine(_tempRoot, "xdg");
+        Environment.SetEnvironmentVariable("XDG_DATA_HOME", xdgRoot);
+
+        var resolved = DriftbusterPaths.GetDataRoot();
+
+        resolved.Should().Be(Path.Combine(xdgRoot, "DriftBuster"));
+        Directory.Exists(resolved).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Cache_and_session_directories_append_non_blank_segments()
+    {
+        var baseRoot = Path.Combine(_tempRoot, "paths");
+        Environment.SetEnvironmentVariable("DRIFTBUSTER_DATA_ROOT", baseRoot);
+
+        var cache = DriftbusterPaths.GetCacheDirectory("diff-planner", "", "history");
+        var sessions = DriftbusterPaths.GetSessionDirectory("multi-server", " ", "snapshots");
+
+        cache.Should().Be(Path.Combine(baseRoot, "cache", "diff-planner", "history"));
+        sessions.Should().Be(Path.Combine(baseRoot, "sessions", "multi-server", "snapshots"));
+        Directory.Exists(cache).Should().BeTrue();
+        Directory.Exists(sessions).Should().BeTrue();
+    }
+}

--- a/gui/DriftBuster.Gui.Tests/Converters/BooleanNegationConverterTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Converters/BooleanNegationConverterTests.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+
+using DriftBuster.Gui.Converters;
+
+namespace DriftBuster.Gui.Tests.Converters;
+
+public sealed class BooleanNegationConverterTests
+{
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void Convert_negates_boolean_values(bool input, bool expected)
+    {
+        var converter = BooleanNegationConverter.Instance;
+
+        converter.Convert(input, typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(null, true)]
+    public void Convert_negates_nullable_boolean_values(bool? input, bool expected)
+    {
+        var converter = BooleanNegationConverter.Instance;
+
+        converter.Convert(input, typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Convert_defaults_to_true_for_non_boolean_values()
+    {
+        var converter = BooleanNegationConverter.Instance;
+
+        converter.Convert("unexpected", typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(true);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void ConvertBack_negates_boolean_values(bool input, bool expected)
+    {
+        var converter = BooleanNegationConverter.Instance;
+
+        converter.ConvertBack(input, typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ConvertBack_defaults_to_true_for_non_boolean_values()
+    {
+        var converter = BooleanNegationConverter.Instance;
+
+        converter.ConvertBack("unexpected", typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(true);
+    }
+}

--- a/gui/DriftBuster.Gui.Tests/Converters/DiffJsonViewModeMatchConverterTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Converters/DiffJsonViewModeMatchConverterTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+using Avalonia.Data;
+
+using DriftBuster.Gui.Converters;
+
+namespace DriftBuster.Gui.Tests.Converters;
+
+public sealed class DiffJsonViewModeMatchConverterTests
+{
+    [Fact]
+    public void Convert_returns_false_when_values_are_missing()
+    {
+        var converter = DiffJsonViewModeMatchConverter.Instance;
+
+        converter.Convert(new List<object?>(), typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(false);
+        converter.Convert(new List<object?> { "left" }, typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(false);
+    }
+
+    [Fact]
+    public void Convert_returns_false_when_any_side_is_null()
+    {
+        var converter = DiffJsonViewModeMatchConverter.Instance;
+
+        converter.Convert(new List<object?> { null, "raw" }, typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(false);
+        converter.Convert(new List<object?> { "raw", null }, typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(false);
+    }
+
+    [Fact]
+    public void Convert_compares_values_for_equality()
+    {
+        var converter = DiffJsonViewModeMatchConverter.Instance;
+
+        converter.Convert(new List<object?> { "raw", "raw" }, typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(true);
+        converter.Convert(new List<object?> { "raw", "sanitized" }, typeof(bool), null, CultureInfo.InvariantCulture).Should().Be(false);
+    }
+
+    [Fact]
+    public void ConvertBack_returns_do_nothing_marker()
+    {
+        var converter = DiffJsonViewModeMatchConverter.Instance;
+
+        var result = converter.ConvertBack(new List<object?>(), typeof(object), null, CultureInfo.InvariantCulture);
+
+        result.Should().Be(BindingOperations.DoNothing);
+    }
+}

--- a/gui/DriftBuster.Gui.Tests/Converters/RootStatusToBrushConverterTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Converters/RootStatusToBrushConverterTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Globalization;
+
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+
+using DriftBuster.Gui.Converters;
+using DriftBuster.Gui.Tests.Ui;
+using DriftBuster.Gui.ViewModels;
+
+namespace DriftBuster.Gui.Tests.Converters;
+
+[Collection(HeadlessCollection.Name)]
+public sealed class RootStatusToBrushConverterTests
+{
+    [AvaloniaTheory]
+    [InlineData(RootValidationState.Valid, "#144f2a")]
+    [InlineData(RootValidationState.Invalid, "#64241f")]
+    [InlineData(RootValidationState.Pending, "#1e293b")]
+    public void Convert_maps_state_to_expected_color(RootValidationState state, string hex)
+    {
+        var converter = RootStatusToBrushConverter.Instance;
+
+        var result = converter.Convert(state, typeof(IBrush), null, CultureInfo.InvariantCulture);
+
+        var brush = result.Should().BeOfType<SolidColorBrush>().Subject;
+        brush.Color.Should().Be(Color.Parse(hex));
+    }
+
+    [AvaloniaFact]
+    public void Convert_defaults_to_pending_for_non_enum_values()
+    {
+        var converter = RootStatusToBrushConverter.Instance;
+
+        var result = converter.Convert("not-a-state", typeof(IBrush), null, CultureInfo.InvariantCulture);
+
+        var brush = result.Should().BeOfType<SolidColorBrush>().Subject;
+        brush.Color.Should().Be(Color.Parse("#1e293b"));
+    }
+
+    [AvaloniaFact]
+    public void ConvertBack_is_not_supported()
+    {
+        var converter = RootStatusToBrushConverter.Instance;
+
+        Action act = () => converter.ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/gui/DriftBuster.Gui.Tests/DebugEnvironmentInitializer.cs
+++ b/gui/DriftBuster.Gui.Tests/DebugEnvironmentInitializer.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace DriftBuster.Gui.Tests;
+
+internal static class DebugEnvironmentInitializer
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        Environment.SetEnvironmentVariable("DRIFTBUSTER_DEBUG", "1");
+    }
+}

--- a/gui/DriftBuster.Gui.Tests/EnvironmentVariablesCollection.cs
+++ b/gui/DriftBuster.Gui.Tests/EnvironmentVariablesCollection.cs
@@ -1,0 +1,6 @@
+namespace DriftBuster.Gui.Tests;
+
+public static class EnvironmentVariablesCollection
+{
+    public const string Name = "EnvironmentVariables";
+}

--- a/gui/DriftBuster.Gui.Tests/EnvironmentVariablesCollectionDefinition.cs
+++ b/gui/DriftBuster.Gui.Tests/EnvironmentVariablesCollectionDefinition.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+namespace DriftBuster.Gui.Tests;
+
+[CollectionDefinition(EnvironmentVariablesCollection.Name, DisableParallelization = true)]
+public sealed class EnvironmentVariablesCollectionDefinition;

--- a/gui/DriftBuster.Gui.Tests/Services/AutomationDispatcherTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Services/AutomationDispatcherTests.cs
@@ -1,0 +1,200 @@
+#if DEBUG
+using System.Text.Json;
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Styling;
+
+using DriftBuster.Backend.Models;
+using DriftBuster.Gui.Services;
+using DriftBuster.Gui.Tests.Fakes;
+using DriftBuster.Gui.Tests.Ui;
+using DriftBuster.Gui.ViewModels;
+
+namespace DriftBuster.Gui.Tests.Services;
+
+[Collection(HeadlessCollection.Name)]
+public sealed class AutomationDispatcherTests
+{
+    [AvaloniaFact]
+    public void Navigate_multi_server_catalog_requires_catalog_entries()
+    {
+        var fixture = CreateFixture();
+
+        using var response = fixture.Dispatch(new { cmd = "navigate", tab = "multi-server/catalog" });
+
+        response.RootElement.GetProperty("ok").GetBoolean().Should().BeFalse();
+        response.RootElement.GetProperty("error").GetString().Should().Contain("Catalog view is unavailable");
+    }
+
+    [AvaloniaTheory]
+    [InlineData("multi-server/catalog")]
+    [InlineData("multiserver/catalog")]
+    public void Navigate_multi_server_catalog_activates_catalog_view_when_entries_exist(string tab)
+    {
+        var fixture = CreateFixture();
+        fixture.PopulateCatalog();
+
+        using var response = fixture.Dispatch(new { cmd = "navigate", tab });
+
+        response.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue();
+        fixture.ServerViewModel.IsViewingCatalog.Should().BeTrue();
+        fixture.ServerViewModel.IsViewingDrilldown.Should().BeFalse();
+    }
+
+    [AvaloniaFact]
+    public void Navigate_multi_server_drilldown_requires_loaded_drilldown()
+    {
+        var fixture = CreateFixture();
+
+        using var response = fixture.Dispatch(new { cmd = "navigate", tab = "multi-server/drilldown" });
+
+        response.RootElement.GetProperty("ok").GetBoolean().Should().BeFalse();
+        response.RootElement.GetProperty("error").GetString().Should().Contain("Drilldown view is unavailable");
+    }
+
+    [AvaloniaFact]
+    public void Navigate_multi_server_drilldown_activates_drilldown_when_available()
+    {
+        var fixture = CreateFixture();
+        fixture.PopulateDrilldown();
+
+        using var response = fixture.Dispatch(new { cmd = "navigate", tab = "multi-server/drilldown" });
+
+        response.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue();
+        fixture.ServerViewModel.IsViewingCatalog.Should().BeFalse();
+        fixture.ServerViewModel.IsViewingDrilldown.Should().BeTrue();
+    }
+
+    [AvaloniaTheory]
+    [InlineData("multi-server/setup")]
+    [InlineData("multiserver/setup")]
+    public void Navigate_multi_server_setup_returns_to_setup_sub_view(string tab)
+    {
+        var fixture = CreateFixture();
+        fixture.PopulateCatalog();
+        fixture.ServerViewModel.ShowCatalogCommand.Execute(null);
+
+        using var response = fixture.Dispatch(new { cmd = "navigate", tab });
+
+        response.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue();
+        fixture.ServerViewModel.IsViewingCatalog.Should().BeFalse();
+        fixture.ServerViewModel.IsViewingDrilldown.Should().BeFalse();
+    }
+
+    [AvaloniaFact]
+    public void Navigate_rejects_unknown_multi_server_sub_view()
+    {
+        var fixture = CreateFixture();
+
+        using var response = fixture.Dispatch(new { cmd = "navigate", tab = "multi-server/unknown" });
+
+        response.RootElement.GetProperty("ok").GetBoolean().Should().BeFalse();
+        response.RootElement.GetProperty("error").GetString().Should().Contain("Unknown multi-server sub-view");
+    }
+
+    private static DispatcherFixture CreateFixture()
+    {
+        var service = new FakeDriftbusterService();
+        var toast = new ToastService(action => action());
+        var serverViewModel = new ServerSelectionViewModel(service, toast, new InMemorySessionCacheService());
+
+        object ServerSelectionFactory(IDriftbusterService _, IToastService __, PerformanceProfile ___)
+            => new Border { DataContext = serverViewModel };
+
+        var mainViewModel = new MainWindowViewModel(
+            service,
+            toast,
+            _ => new object(),
+            (_, _) => new object(),
+            _ => new object(),
+            ServerSelectionFactory,
+            themeRuntime: new StubThemeRuntime());
+
+        var dispatcher = new AutomationDispatcher(mainViewModel);
+        return new DispatcherFixture(dispatcher, serverViewModel);
+    }
+
+    private sealed class DispatcherFixture
+    {
+        public DispatcherFixture(AutomationDispatcher dispatcher, ServerSelectionViewModel serverViewModel)
+        {
+            Dispatcher = dispatcher;
+            ServerViewModel = serverViewModel;
+        }
+
+        public AutomationDispatcher Dispatcher { get; }
+
+        public ServerSelectionViewModel ServerViewModel { get; }
+
+        public JsonDocument Dispatch(object payload)
+        {
+            var response = Dispatcher.Dispatch(JsonSerializer.Serialize(payload));
+            return JsonDocument.Parse(response);
+        }
+
+        public void PopulateCatalog()
+        {
+            ServerViewModel.CatalogViewModel.LoadFromResponse(
+                new ServerScanResponse
+                {
+                    Catalog = new[]
+                    {
+                        new ConfigCatalogEntry
+                        {
+                            ConfigId = "plugins",
+                            DisplayName = "plugins.conf",
+                            Format = "ini",
+                            DriftCount = 1,
+                            Severity = "medium",
+                            PresentHosts = new[] { "App Inc" },
+                            MissingHosts = Array.Empty<string>(),
+                            CoverageStatus = "full",
+                            LastUpdated = DateTimeOffset.UtcNow,
+                        },
+                    },
+                },
+                1);
+        }
+
+        public void PopulateDrilldown()
+        {
+            ServerViewModel.DrilldownViewModel = new ConfigDrilldownViewModel(new ConfigDrilldown
+            {
+                ConfigId = "plugins",
+                DisplayName = "plugins.conf",
+                Format = "ini",
+                DriftCount = 1,
+                BaselineHostId = "server01",
+                DiffBefore = "before",
+                DiffAfter = "after",
+                UnifiedDiff = string.Empty,
+                Servers = new[]
+                {
+                    new ConfigServerDetail
+                    {
+                        HostId = "server01",
+                        Label = "App Inc",
+                        Present = true,
+                        IsBaseline = true,
+                        Status = "Baseline",
+                    },
+                },
+            });
+        }
+    }
+
+    private sealed class StubThemeRuntime : IThemeRuntime
+    {
+        private static readonly ThemeOption s_default = new("dark-plus", "Dark+", ThemeVariant.Dark, "Palette.DarkPlus");
+
+        public IReadOnlyList<ThemeOption> GetAvailableThemes() => new[] { s_default };
+
+        public ThemeOption GetDefaultTheme(IReadOnlyList<ThemeOption> options) => options[0];
+
+        public void ApplyTheme(ThemeOption option)
+        {
+        }
+    }
+}
+#endif

--- a/gui/DriftBuster.Gui.Tests/Services/AutomationServerTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Services/AutomationServerTests.cs
@@ -1,0 +1,85 @@
+#if DEBUG
+#pragma warning disable MA0004
+
+using System.Text.Json;
+
+using DriftBuster.Gui.Services;
+
+namespace DriftBuster.Gui.Tests.Services;
+
+public sealed class AutomationServerTests
+{
+    [Fact]
+    public async Task DispatchWithTimeoutAsync_returns_dispatch_result_when_completed_in_time()
+    {
+        using var cts = new CancellationTokenSource();
+
+        var response = await AutomationServer.DispatchWithTimeoutAsync(
+            () => Task.FromResult("ok-response"),
+            TimeSpan.FromMilliseconds(100),
+            cts.Token);
+
+        response.Should().Be("ok-response");
+    }
+
+    [Fact]
+    public async Task DispatchWithTimeoutAsync_returns_timeout_error_when_dispatch_exceeds_timeout()
+    {
+        using var cts = new CancellationTokenSource();
+
+        var response = await AutomationServer.DispatchWithTimeoutAsync(
+            async () =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(120));
+                return "late-response";
+            },
+            TimeSpan.FromMilliseconds(10),
+            cts.Token);
+
+        using var doc = JsonDocument.Parse(response);
+        doc.RootElement.GetProperty("ok").GetBoolean().Should().BeFalse();
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("timed out");
+    }
+
+    [Fact]
+    public async Task DispatchWithTimeoutAsync_honors_cancellation()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(15));
+
+        Func<Task> act = async () => await AutomationServer.DispatchWithTimeoutAsync(
+            async () =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
+                return "late-response";
+            },
+            TimeSpan.FromSeconds(5),
+            cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Theory]
+    [InlineData("250", 250)]
+    [InlineData("0007", 7)]
+    public void ParseUiDispatchTimeout_parses_positive_integer_milliseconds(string candidate, int expectedMs)
+    {
+        var timeout = AutomationServer.ParseUiDispatchTimeout(candidate);
+
+        timeout.Should().Be(TimeSpan.FromMilliseconds(expectedMs));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("0")]
+    [InlineData("-5")]
+    [InlineData("abc")]
+    public void ParseUiDispatchTimeout_falls_back_to_default_for_invalid_values(string? candidate)
+    {
+        var timeout = AutomationServer.ParseUiDispatchTimeout(candidate);
+
+        timeout.Should().Be(AutomationServer.DefaultUiDispatchTimeout);
+    }
+}
+#endif

--- a/gui/DriftBuster.Gui.Tests/Services/DebugFileLoggerTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Services/DebugFileLoggerTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using DriftBuster.Gui.Services;
+
+namespace DriftBuster.Gui.Tests.Services;
+
+public sealed class DebugFileLoggerTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public DebugFileLoggerTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "driftbuster-debug-log-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_requires_non_empty_path(string? path)
+    {
+        Action act = () => _ = new DebugFileLogger(path!);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Write_appends_json_line()
+    {
+        var path = Path.Combine(_tempRoot, "logs", "debug.jsonl");
+        var logger = new DebugFileLogger(path);
+
+        logger.Write("automation", "started", new { Pipe = "test" });
+
+        File.Exists(path).Should().BeTrue();
+        var lines = File.ReadAllLines(path);
+        lines.Should().ContainSingle();
+
+        using var payload = JsonDocument.Parse(lines[0]);
+        var root = payload.RootElement;
+        root.GetProperty("category").GetString().Should().Be("automation");
+        root.GetProperty("message").GetString().Should().Be("started");
+        root.GetProperty("detail").GetProperty("pipe").GetString().Should().Be("test");
+    }
+
+    [Fact]
+    public void Write_skips_unserializable_payload()
+    {
+        var path = Path.Combine(_tempRoot, "debug.jsonl");
+        var logger = new DebugFileLogger(path);
+        var cyclic = new CyclicDetail();
+        cyclic.Self = cyclic;
+
+        logger.Write("cycle", "serialize", cyclic);
+
+        File.Exists(path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Write_stops_appending_when_file_cap_is_reached()
+    {
+        var path = Path.Combine(_tempRoot, "debug.jsonl");
+        var seed = new byte[(10 * 1024 * 1024) + 32];
+        File.WriteAllBytes(path, seed);
+        var initialLength = new FileInfo(path).Length;
+
+        var logger = new DebugFileLogger(path);
+
+        logger.Write("cap", "first");
+        logger.Write("cap", "second");
+
+        var finalLength = new FileInfo(path).Length;
+        finalLength.Should().Be(initialLength);
+    }
+
+    [Fact]
+    public void Write_handles_invalid_path_without_throwing()
+    {
+        var path = Path.Combine(_tempRoot, "bad" + '\0' + "name.jsonl");
+        var logger = new DebugFileLogger(path);
+
+        Action act = () => logger.Write("io", "failure");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void DefaultLogPath_targets_logs_debug_jsonl()
+    {
+        var path = DebugFileLogger.DefaultLogPath();
+
+        path.Should().EndWith(Path.Combine("logs", "debug.jsonl"));
+    }
+
+    private sealed class CyclicDetail
+    {
+        public CyclicDetail? Self { get; set; }
+    }
+}

--- a/gui/DriftBuster.Gui.Tests/Services/DiffPlannerMruStoreTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Services/DiffPlannerMruStoreTests.cs
@@ -166,8 +166,8 @@ public sealed class DiffPlannerMruStoreTests
         using var temp = new TempDirectory();
         var store = new DiffPlannerMruStore(temp.Path);
 
-        Func<Task> saveAct = async () => await store.SaveAsync(null!);
-        Func<Task> recordAct = async () => await store.RecordAsync(null!);
+        Func<Task> saveAct = () => store.SaveAsync(null!);
+        Func<Task> recordAct = () => store.RecordAsync(null!);
 
         await saveAct.Should().ThrowAsync<ArgumentNullException>();
         await recordAct.Should().ThrowAsync<ArgumentNullException>();

--- a/gui/DriftBuster.Gui.Tests/Services/DiffPlannerMruStoreTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Services/DiffPlannerMruStoreTests.cs
@@ -160,6 +160,94 @@ public sealed class DiffPlannerMruStoreTests
         entry.LastUsedUtc.Should().Be(new DateTimeOffset(2025, 3, 4, 5, 6, 7, TimeSpan.Zero));
     }
 
+    [Fact]
+    public async Task SaveAsync_and_RecordAsync_validate_null_arguments()
+    {
+        using var temp = new TempDirectory();
+        var store = new DiffPlannerMruStore(temp.Path);
+
+        Func<Task> saveAct = async () => await store.SaveAsync(null!);
+        Func<Task> recordAct = async () => await store.RecordAsync(null!);
+
+        await saveAct.Should().ThrowAsync<ArgumentNullException>();
+        await recordAct.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task LoadAsync_returns_empty_snapshot_for_invalid_json()
+    {
+        using var temp = new TempDirectory();
+        var directory = Path.Combine(temp.Path, "diff-planner");
+        Directory.CreateDirectory(directory);
+        await File.WriteAllTextAsync(Path.Combine(directory, "mru.json"), "{ invalid json");
+
+        var store = new DiffPlannerMruStore(temp.Path);
+        var snapshot = await store.LoadAsync();
+
+        snapshot.Entries.Should().BeEmpty();
+        snapshot.MaxEntries.Should().Be(DiffPlannerMruStore.DefaultEntryLimit);
+    }
+
+    [Fact]
+    public async Task ClearAsync_removes_store_file()
+    {
+        using var temp = new TempDirectory();
+        var store = new DiffPlannerMruStore(temp.Path);
+        await store.SaveAsync(new DiffPlannerMruSnapshot
+        {
+            Entries =
+            {
+                new DiffPlannerMruEntry
+                {
+                    BaselinePath = "/baseline.json",
+                    ComparisonPaths = { "/compare.json" },
+                },
+            },
+        });
+
+        var storeFile = Path.Combine(temp.Path, "diff-planner", "mru.json");
+        File.Exists(storeFile).Should().BeTrue();
+
+        await store.ClearAsync();
+
+        File.Exists(storeFile).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Migration_ignores_legacy_when_destination_exists()
+    {
+        using var temp = new TempDirectory();
+        var destinationDirectory = Path.Combine(temp.Path, "diff-planner");
+        Directory.CreateDirectory(destinationDirectory);
+        var destinationFile = Path.Combine(destinationDirectory, "mru.json");
+        await File.WriteAllTextAsync(destinationFile, JsonSerializer.Serialize(new DiffPlannerMruSnapshot
+        {
+            Entries =
+            {
+                new DiffPlannerMruEntry
+                {
+                    BaselinePath = "/current-baseline.json",
+                    ComparisonPaths = { "/current-compare.json" },
+                },
+            },
+        }, SerializerOptions));
+
+        var legacyPath = Path.Combine(temp.Path, "legacy.json");
+        var legacyPayload = new LegacyDiffPlannerSettings
+        {
+            BaselinePath = "/legacy-baseline.json",
+            ComparisonPaths = new[] { "/legacy-compare.json" },
+            MaxEntries = 1,
+        };
+        await File.WriteAllTextAsync(legacyPath, JsonSerializer.Serialize(legacyPayload, SerializerOptions));
+
+        var store = new DiffPlannerMruStore(temp.Path, legacyPath, null);
+        var snapshot = await store.LoadAsync();
+
+        snapshot.Entries.Should().ContainSingle();
+        snapshot.Entries[0].BaselinePath.Should().Be("/current-baseline.json");
+    }
+
     private sealed class TempDirectory : IDisposable
     {
         public TempDirectory()

--- a/gui/DriftBuster.Gui.Tests/Services/PerformanceProfileTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Services/PerformanceProfileTests.cs
@@ -1,7 +1,9 @@
 using DriftBuster.Gui.Services;
+using DriftBuster.Gui.Tests;
 
 namespace DriftBuster.Gui.Tests.Services;
 
+[Collection(EnvironmentVariablesCollection.Name)]
 public sealed class PerformanceProfileTests : IDisposable
 {
     private readonly string? _origThreshold;

--- a/gui/DriftBuster.Gui.Tests/Services/ResponsiveLayoutServiceTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Services/ResponsiveLayoutServiceTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+
+using Avalonia.Headless.XUnit;
+using Avalonia.Controls;
+
+using DriftBuster.Gui.Services;
+using DriftBuster.Gui.Tests.Ui;
+
+namespace DriftBuster.Gui.Tests.Services;
+
+[Collection(HeadlessCollection.Name)]
+public sealed class ResponsiveLayoutServiceTests
+{
+    [AvaloniaFact]
+    public void Apply_requires_control_and_breakpoints()
+    {
+        var control = new Border();
+
+        Action nullControl = () => ResponsiveLayoutService.Apply(null!, 1200, new List<ResponsiveBreakpoint>
+        {
+            new(0, new Dictionary<string, object>(StringComparer.Ordinal)),
+        });
+
+        Action emptyBreakpoints = () => ResponsiveLayoutService.Apply(control, 1200, Array.Empty<ResponsiveBreakpoint>());
+
+        nullControl.Should().Throw<ArgumentNullException>();
+        emptyBreakpoints.Should().Throw<ArgumentException>();
+    }
+
+    [AvaloniaFact]
+    public void Attach_requires_control_and_breakpoints()
+    {
+        var control = new Border();
+
+        Action nullControl = () => ResponsiveLayoutService.Attach(null!, new List<ResponsiveBreakpoint>
+        {
+            new(0, new Dictionary<string, object>(StringComparer.Ordinal)),
+        });
+
+        Action emptyBreakpoints = () => ResponsiveLayoutService.Attach(control, Array.Empty<ResponsiveBreakpoint>());
+
+        nullControl.Should().Throw<ArgumentNullException>();
+        emptyBreakpoints.Should().Throw<ArgumentException>();
+    }
+
+    [AvaloniaFact]
+    public void Apply_selects_last_matching_breakpoint()
+    {
+        var control = new Border();
+        var breakpoints = new[]
+        {
+            new ResponsiveBreakpoint(0, new Dictionary<string, object>(StringComparer.Ordinal) { ["Layout.Padding"] = 8d }),
+            new ResponsiveBreakpoint(1000, new Dictionary<string, object>(StringComparer.Ordinal) { ["Layout.Padding"] = 12d }),
+            new ResponsiveBreakpoint(1600, new Dictionary<string, object>(StringComparer.Ordinal) { ["Layout.Padding"] = 20d }),
+        };
+
+        ResponsiveLayoutService.Apply(control, 999, breakpoints);
+        control.Resources["Layout.Padding"].Should().Be(8d);
+
+        ResponsiveLayoutService.Apply(control, 1000, breakpoints);
+        control.Resources["Layout.Padding"].Should().Be(12d);
+
+        ResponsiveLayoutService.Apply(control, 2200, breakpoints);
+        control.Resources["Layout.Padding"].Should().Be(20d);
+    }
+
+    [AvaloniaFact]
+    public void Attach_returns_disposable_that_is_safe_to_dispose_multiple_times()
+    {
+        var control = new Border();
+        var breakpoints = new[]
+        {
+            new ResponsiveBreakpoint(0, new Dictionary<string, object>(StringComparer.Ordinal) { ["Layout.Padding"] = 8d }),
+        };
+
+        var handle = ResponsiveLayoutService.Attach(control, breakpoints);
+
+        control.Resources["Layout.Padding"].Should().Be(8d);
+
+        Action disposeTwice = () =>
+        {
+            handle.Dispose();
+            handle.Dispose();
+        };
+
+        disposeTwice.Should().NotThrow();
+    }
+}

--- a/gui/DriftBuster.Gui.Tests/Services/SessionCacheServiceTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Services/SessionCacheServiceTests.cs
@@ -250,6 +250,98 @@ public sealed class SessionCacheServiceTests
         finalSnapshot!.ActivityFilter.Should().NotBeNull();
     }
 
+    [Fact]
+    public async Task SaveAsync_throws_for_null_snapshot()
+    {
+        using var temp = new TempDirectory();
+        var service = new SessionCacheService(temp.Path);
+
+        Func<Task> act = async () => await service.SaveAsync(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task Default_migration_copies_legacy_cache_when_destination_missing()
+    {
+        SessionCacheMigrationCounters.Reset();
+
+        using var temp = new TempDirectory();
+        var legacyPath = Path.Combine(temp.Path, "legacy", "multi-server.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyPath)!);
+
+        var legacySnapshot = new ServerSelectionCache
+        {
+            PersistSession = true,
+            ActivityFilter = "legacy",
+        };
+
+        await File.WriteAllTextAsync(legacyPath, JsonSerializer.Serialize(legacySnapshot, SerializerOptions));
+
+        var service = new SessionCacheService(temp.Path, legacyPath, migrationHandler: null);
+        var loaded = await service.LoadAsync();
+
+        loaded.Should().NotBeNull();
+        loaded!.ActivityFilter.Should().Be("legacy");
+        File.Exists(Path.Combine(temp.Path, "multi-server.json")).Should().BeTrue();
+        SessionCacheMigrationCounters.Successes.Should().Be(1);
+        SessionCacheMigrationCounters.Failures.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Default_migration_is_skipped_when_destination_exists()
+    {
+        SessionCacheMigrationCounters.Reset();
+
+        using var temp = new TempDirectory();
+        var destinationPath = Path.Combine(temp.Path, "multi-server.json");
+        var destinationSnapshot = new ServerSelectionCache
+        {
+            PersistSession = false,
+            ActivityFilter = "current",
+        };
+        await File.WriteAllTextAsync(destinationPath, JsonSerializer.Serialize(destinationSnapshot, SerializerOptions));
+
+        var legacyPath = Path.Combine(temp.Path, "legacy", "multi-server.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyPath)!);
+        await File.WriteAllTextAsync(legacyPath, "{\"activity_filter\":\"legacy\"}");
+
+        var service = new SessionCacheService(temp.Path, legacyPath, migrationHandler: null);
+        var loaded = await service.LoadAsync();
+
+        loaded.Should().NotBeNull();
+        loaded!.ActivityFilter.Should().Be("current");
+        SessionCacheMigrationCounters.Successes.Should().Be(0);
+        SessionCacheMigrationCounters.Failures.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Clear_waits_for_in_progress_migration()
+    {
+        using var temp = new TempDirectory();
+        var legacyPath = Path.Combine(temp.Path, "legacy", "multi-server.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyPath)!);
+        await File.WriteAllTextAsync(legacyPath, "{}");
+
+        var migrationStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var migrationRelease = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task BlockingMigration(string _, string __, CancellationToken ___)
+        {
+            migrationStarted.TrySetResult(true);
+            return migrationRelease.Task;
+        }
+
+        var service = new SessionCacheService(temp.Path, legacyPath, BlockingMigration);
+        var clearTask = Task.Run(service.Clear);
+
+        await migrationStarted.Task;
+        clearTask.IsCompleted.Should().BeFalse();
+
+        migrationRelease.TrySetResult(true);
+        await clearTask;
+    }
+
     private sealed class TempDirectory : IDisposable
     {
         public TempDirectory()

--- a/gui/DriftBuster.Gui.Tests/Services/SessionCacheServiceTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Services/SessionCacheServiceTests.cs
@@ -256,7 +256,7 @@ public sealed class SessionCacheServiceTests
         using var temp = new TempDirectory();
         var service = new SessionCacheService(temp.Path);
 
-        Func<Task> act = async () => await service.SaveAsync(null!);
+        Func<Task> act = () => service.SaveAsync(null!);
 
         await act.Should().ThrowAsync<ArgumentNullException>();
     }

--- a/gui/DriftBuster.Gui.Tests/Services/ToastNotificationTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Services/ToastNotificationTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+
+using DriftBuster.Gui.Services;
+
+namespace DriftBuster.Gui.Tests.Services;
+
+public sealed class ToastNotificationTests
+{
+    [Fact]
+    public void Dismiss_command_invokes_dismiss_callback()
+    {
+        Guid? dismissed = null;
+        var id = Guid.NewGuid();
+        var notification = new ToastNotification(
+            id,
+            "Info",
+            "Body",
+            ToastLevel.Info,
+            TimeSpan.FromSeconds(2),
+            primaryAction: null,
+            secondaryAction: null,
+            dismiss: value => dismissed = value);
+
+        notification.DismissCommand.Execute(null);
+
+        dismissed.Should().Be(id);
+        notification.PrimaryCommand.Should().BeNull();
+        notification.SecondaryCommand.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Primary_and_secondary_actions_run_callbacks()
+    {
+        var id = Guid.NewGuid();
+        var primaryRuns = 0;
+        var secondaryRuns = 0;
+        Guid? dismissed = null;
+
+        var notification = new ToastNotification(
+            id,
+            "Actions",
+            "Body",
+            ToastLevel.Warning,
+            TimeSpan.FromSeconds(5),
+            new ToastAction("Primary", () =>
+            {
+                primaryRuns++;
+                return Task.CompletedTask;
+            }, CloseOnInvoke: true),
+            new ToastAction("Secondary", () =>
+            {
+                secondaryRuns++;
+                return Task.CompletedTask;
+            }, CloseOnInvoke: false),
+            dismiss: value => dismissed = value);
+
+        notification.PrimaryLabel.Should().Be("Primary");
+        notification.SecondaryLabel.Should().Be("Secondary");
+
+        await notification.PrimaryCommand!.ExecuteAsync(null);
+        await notification.SecondaryCommand!.ExecuteAsync(null);
+
+        primaryRuns.Should().Be(1);
+        secondaryRuns.Should().Be(1);
+        dismissed.Should().Be(id);
+    }
+
+    [Fact]
+    public void Exposes_timestamp_and_level_labels()
+    {
+        var notification = new ToastNotification(
+            Guid.NewGuid(),
+            "Title",
+            "Message",
+            ToastLevel.Error,
+            TimeSpan.FromSeconds(1),
+            primaryAction: null,
+            secondaryAction: null,
+            dismiss: _ => { });
+
+        notification.LevelLabel.Should().Be("Error");
+        notification.TimestampText.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/gui/DriftBuster.Gui.Tests/Ui/PerformanceSmokeTests.cs
+++ b/gui/DriftBuster.Gui.Tests/Ui/PerformanceSmokeTests.cs
@@ -3,11 +3,13 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using DriftBuster.Gui.Services;
+using DriftBuster.Gui.Tests;
 
 using Xunit;
 
 namespace DriftBuster.Gui.Tests.Ui;
 
+[Collection(EnvironmentVariablesCollection.Name)]
 public sealed class PerformanceSmokeTests
 {
     [Fact]

--- a/gui/DriftBuster.Gui.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/gui/DriftBuster.Gui.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -134,6 +134,68 @@ public class MainWindowViewModelTests
         runtime.Applied[^1].Id.Should().Be("light-plus");
     }
 
+    [Fact]
+    public void ShowMultiServer_uses_server_factory_and_exposes_performance_profile()
+    {
+        var service = new FakeDriftbusterService { PingResponse = "pong" };
+        var toastService = new ToastService(action => action());
+        var runtime = CreateDefaultThemeRuntime();
+        var expectedProfile = new PerformanceProfile(virtualizationThreshold: 123, forceVirtualizationOverride: true);
+        var serverView = new object();
+
+        object ServerFactory(IDriftbusterService _, IToastService __, PerformanceProfile profile)
+        {
+            profile.VirtualizationThreshold.Should().Be(expectedProfile.VirtualizationThreshold);
+            profile.ForceVirtualizationOverride.Should().Be(expectedProfile.ForceVirtualizationOverride);
+            return serverView;
+        }
+
+        var viewModel = new MainWindowViewModel(
+            service,
+            toastService,
+            _ => new object(),
+            (_, _) => new object(),
+            _ => new object(),
+            ServerFactory,
+            performanceProfile: expectedProfile,
+            themeRuntime: runtime);
+
+        viewModel.ShowMultiServerCommand.Execute(null);
+
+        viewModel.IsMultiServerSelected.Should().BeTrue();
+        viewModel.CurrentView.Should().BeSameAs(serverView);
+        viewModel.PerformanceProfile.Should().BeSameAs(expectedProfile);
+    }
+
+    [Fact]
+    public void Theme_selector_ignores_null_selection_changes()
+    {
+        var options = new List<ThemeOption>
+        {
+            new("dark-plus", "Dark+", ThemeVariant.Dark, "Palette.DarkPlus"),
+            new("light-plus", "Light+", ThemeVariant.Light, "Palette.LightPlus"),
+        };
+
+        var runtime = new FakeThemeRuntime(options);
+        var service = new FakeDriftbusterService { PingResponse = "pong" };
+        var toastService = new ToastService(action => action());
+        var viewModel = new MainWindowViewModel(
+            service,
+            toastService,
+            _ => new object(),
+            (_, _) => new object(),
+            _ => new object(),
+            themeRuntime: runtime);
+
+        runtime.Applied.Should().HaveCount(1);
+
+        viewModel.SelectedTheme = null;
+
+        runtime.Applied.Should().HaveCount(1);
+        viewModel.SelectedTheme = options[1];
+        runtime.Applied.Should().HaveCount(2);
+    }
+
     private static FakeThemeRuntime CreateDefaultThemeRuntime()
     {
         return new FakeThemeRuntime(new List<ThemeOption>

--- a/gui/DriftBuster.Gui.Tests/ViewModels/ServerSelectionViewModelAdditionalTests.cs
+++ b/gui/DriftBuster.Gui.Tests/ViewModels/ServerSelectionViewModelAdditionalTests.cs
@@ -1,8 +1,6 @@
 using System.Reflection;
 using System.Text.Json;
 
-using CommunityToolkit.Mvvm.Input;
-
 using DriftBuster.Backend.Models;
 using DriftBuster.Gui.Services;
 using DriftBuster.Gui.Tests.Fakes;
@@ -112,22 +110,21 @@ public sealed class ServerSelectionViewModelAdditionalTests
         server.IsEnabled.Should().BeTrue();
         AssertDrilldownContainsHost(viewModel, server.HostId);
 
-        viewModel.PersistSessionState = true;
-        PopulateActivityDetailViaReflection(viewModel);
-
-        await PollUntilCanExecuteAsync(viewModel.SaveSessionCommand);
-        await viewModel.SaveSessionCommand.ExecuteAsync(null);
-        await PollForSnapshotAsync(cache);
-
+        var persistenceViewModel = new ServerSelectionViewModel(new FakeDriftbusterService(), toast, cache);
+        persistenceViewModel.PersistSessionState = true;
+        persistenceViewModel.Servers[0].Label = "Persist me";
+        persistenceViewModel.SaveSessionCommand.CanExecute(null).Should().BeTrue();
+        await persistenceViewModel.SaveSessionCommand.ExecuteAsync(null);
         cache.Snapshot.Should().NotBeNull("SaveSessionCommand should have saved snapshot");
+        cache.Snapshot!.Servers.Should().Contain(entry => entry.Label == "Persist me");
 
-        viewModel.ActivityFilter = ActivityFilterOption.Errors;
-        viewModel.ActivityFilter = ActivityFilterOption.All;
+        persistenceViewModel.ActivityFilter = ActivityFilterOption.Errors;
+        persistenceViewModel.ActivityFilter = ActivityFilterOption.All;
 
-        viewModel.ClearHistoryCommand.Execute(null);
+        persistenceViewModel.ClearHistoryCommand.Execute(null);
         cache.Cleared.Should().BeTrue();
-        viewModel.HasActiveServers.Should().BeTrue();
-        viewModel.ShowDrilldownForHostCommand.CanExecute(server.HostId).Should().BeFalse();
+        persistenceViewModel.HasActiveServers.Should().BeTrue();
+        persistenceViewModel.ShowDrilldownForHostCommand.CanExecute(persistenceViewModel.Servers[0].HostId).Should().BeFalse();
     }
 
     [Fact]
@@ -440,49 +437,6 @@ public sealed class ServerSelectionViewModelAdditionalTests
         drilldownDetail.Should().NotBeNull();
         drilldownDetail!.Present.Should().BeTrue();
         viewModel.ShowDrilldownForHostCommand.CanExecute(hostId).Should().BeTrue();
-    }
-
-    /// <summary>
-    /// Populate null Detail properties via reflection to prevent SaveSessionAsync from failing.
-    /// Works around bug in ServerSelectionViewModel.SaveSessionAsync line 881.
-    /// </summary>
-    private static void PopulateActivityDetailViaReflection(ServerSelectionViewModel viewModel)
-    {
-        foreach (var entry in viewModel.ActivityEntries)
-        {
-            if (entry != null)
-            {
-                var detailProp = entry.GetType().GetProperty("Detail");
-                if (detailProp is not null && detailProp.GetValue(entry) is null && detailProp.CanWrite)
-                {
-                    detailProp.SetValue(entry, string.Empty);
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Poll until a command's CanExecute returns true (coverage instrumentation can delay IsBusy transitions).
-    /// </summary>
-    private static async Task PollUntilCanExecuteAsync(IAsyncRelayCommand command, int timeoutMs = 30000)
-    {
-        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
-        while (!command.CanExecute(null) && DateTime.UtcNow < deadline)
-        {
-            await Task.Delay(50).ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>
-    /// Poll for snapshot with generous timeout (coverage instrumentation adds significant overhead).
-    /// </summary>
-    private static async Task PollForSnapshotAsync(InMemorySessionCacheService cache, int timeoutMs = 30000)
-    {
-        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
-        while (cache.Snapshot is null && DateTime.UtcNow < deadline)
-        {
-            await Task.Delay(100).ConfigureAwait(false);
-        }
     }
 
     private static Task<ServerScanResponse> BuildMixedAvailabilityResponse(

--- a/gui/DriftBuster.Gui.Tests/ViewModels/ServerSelectionViewModelAdditionalTests.cs
+++ b/gui/DriftBuster.Gui.Tests/ViewModels/ServerSelectionViewModelAdditionalTests.cs
@@ -258,6 +258,30 @@ public sealed class ServerSelectionViewModelAdditionalTests
     }
 
     [Fact]
+    public async Task RunAll_surfaces_error_state_when_scan_throws()
+    {
+        var service = new FakeDriftbusterService
+        {
+            RunServerScansHandler = (_, _, _) => Task.FromException<ServerScanResponse>(new InvalidOperationException("network down")),
+        };
+        var toast = new ToastService(action => action());
+        var viewModel = new ServerSelectionViewModel(service, toast, new InMemorySessionCacheService());
+
+        await viewModel.RunAllCommand.ExecuteAsync(null);
+
+        viewModel.IsBusy.Should().BeFalse();
+        viewModel.StatusBanner.Should().Be("Scan failed: network down");
+        viewModel.ActivityEntries.Should().Contain(entry =>
+            entry.Severity == ActivitySeverity.Error &&
+            entry.Summary == "Scan failed" &&
+            entry.Detail.Contains("network down", StringComparison.Ordinal));
+        toast.ActiveToasts.Should().Contain(notification =>
+            notification.Level == ToastLevel.Error &&
+            notification.Title == "Multi-server scan failed" &&
+            notification.Message.Contains("network down", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task Provides_deterministic_drilldown_gating_and_telemetry()
     {
         var logPath = Path.Combine("artifacts", "logs", "drilldown-ready.json");
@@ -440,7 +464,7 @@ public sealed class ServerSelectionViewModelAdditionalTests
     /// <summary>
     /// Poll until a command's CanExecute returns true (coverage instrumentation can delay IsBusy transitions).
     /// </summary>
-    private static async Task PollUntilCanExecuteAsync(IAsyncRelayCommand command, int timeoutMs = 10000)
+    private static async Task PollUntilCanExecuteAsync(IAsyncRelayCommand command, int timeoutMs = 30000)
     {
         var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (!command.CanExecute(null) && DateTime.UtcNow < deadline)
@@ -452,7 +476,7 @@ public sealed class ServerSelectionViewModelAdditionalTests
     /// <summary>
     /// Poll for snapshot with generous timeout (coverage instrumentation adds significant overhead).
     /// </summary>
-    private static async Task PollForSnapshotAsync(InMemorySessionCacheService cache, int timeoutMs = 10000)
+    private static async Task PollForSnapshotAsync(InMemorySessionCacheService cache, int timeoutMs = 30000)
     {
         var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (cache.Snapshot is null && DateTime.UtcNow < deadline)

--- a/gui/DriftBuster.Gui.Tests/ViewModels/ServerSelectionViewModelAdditionalTests.cs
+++ b/gui/DriftBuster.Gui.Tests/ViewModels/ServerSelectionViewModelAdditionalTests.cs
@@ -86,6 +86,20 @@ public sealed class ServerSelectionViewModelAdditionalTests
         var viewModel = new ServerSelectionViewModel(service, toast, cache);
 
         var server = viewModel.Servers[0];
+        ConfigureCustomRootFlow(viewModel, server);
+
+        await viewModel.RunAllCommand.ExecuteAsync(null);
+        viewModel.CatalogViewModel.HasEntries.Should().BeTrue();
+        viewModel.FilteredActivityEntries.Should().NotBeEmpty();
+        viewModel.IsBusy.Should().BeFalse();
+        server.IsEnabled.Should().BeTrue();
+        AssertDrilldownContainsHost(viewModel, server.HostId);
+
+        await VerifyStandalonePersistenceFlowAsync(cache, toast);
+    }
+
+    private static void ConfigureCustomRootFlow(ServerSelectionViewModel viewModel, ServerSlotViewModel server)
+    {
         server.Scope = ServerScanScope.CustomRoots;
         var absoluteRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(absoluteRoot);
@@ -103,19 +117,15 @@ public sealed class ServerSelectionViewModelAdditionalTests
         lastRoot.StatusMessage.Should().Contain("absolute");
         viewModel.RemoveRootCommand.Execute(lastRoot);
         server.Roots.Should().ContainSingle();
+    }
 
-        await viewModel.RunAllCommand.ExecuteAsync(null);
-        viewModel.CatalogViewModel.HasEntries.Should().BeTrue();
-        viewModel.FilteredActivityEntries.Should().NotBeEmpty();
-        viewModel.IsBusy.Should().BeFalse();
-        server.IsEnabled.Should().BeTrue();
-        AssertDrilldownContainsHost(viewModel, server.HostId);
-
+    private static async Task VerifyStandalonePersistenceFlowAsync(InMemorySessionCacheService cache, ToastService toast)
+    {
         var persistenceViewModel = new ServerSelectionViewModel(new FakeDriftbusterService(), toast, cache);
         persistenceViewModel.PersistSessionState = true;
         persistenceViewModel.Servers[0].Label = "Persist me";
         persistenceViewModel.SaveSessionCommand.CanExecute(null).Should().BeTrue();
-        await persistenceViewModel.SaveSessionCommand.ExecuteAsync(null);
+        await persistenceViewModel.SaveSessionCommand.ExecuteAsync(null).ConfigureAwait(false);
         cache.Snapshot.Should().NotBeNull("SaveSessionCommand should have saved snapshot");
         cache.Snapshot!.Servers.Should().Contain(entry => entry.Label == "Persist me");
 

--- a/gui/DriftBuster.Gui.Tests/ViewModels/ServerSelectionViewModelAdditionalTests.cs
+++ b/gui/DriftBuster.Gui.Tests/ViewModels/ServerSelectionViewModelAdditionalTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text.Json;
+using System.Threading;
 
 using DriftBuster.Backend.Models;
 using DriftBuster.Gui.Services;
@@ -125,6 +126,37 @@ public sealed class ServerSelectionViewModelAdditionalTests
         cache.Cleared.Should().BeTrue();
         persistenceViewModel.HasActiveServers.Should().BeTrue();
         persistenceViewModel.ShowDrilldownForHostCommand.CanExecute(persistenceViewModel.Servers[0].HostId).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SaveSession_after_run_persists_snapshot_on_same_viewmodel()
+    {
+        var cache = new InMemorySessionCacheService
+        {
+            Snapshot = new ServerSelectionCache
+            {
+                PersistSession = true,
+            },
+        };
+        var service = new FakeDriftbusterService
+        {
+            RunServerScansHandler = CreateScanResponseWithProgress,
+        };
+        var toast = new ToastService(action => action());
+        var viewModel = new ServerSelectionViewModel(service, toast, cache);
+
+        SpinWait.SpinUntil(() => viewModel.PersistSessionState, TimeSpan.FromSeconds(5)).Should().BeTrue();
+        await viewModel.RunAllCommand.ExecuteAsync(null);
+        viewModel.PersistSessionState.Should().BeTrue();
+        var saveMethod = typeof(ServerSelectionViewModel).GetMethod("SaveSessionAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        saveMethod.Should().NotBeNull();
+        var saveTask = (Task?)saveMethod!.Invoke(viewModel, null);
+        saveTask.Should().NotBeNull();
+        await saveTask!;
+        viewModel.StatusBanner.Should().Be("Session saved.");
+
+        cache.Snapshot.Should().NotBeNull();
+        cache.Snapshot!.Servers.Should().Contain(entry => string.Equals(entry.HostId, viewModel.Servers[0].HostId, StringComparison.Ordinal));
     }
 
     [Fact]

--- a/gui/DriftBuster.Gui/App.axaml.cs
+++ b/gui/DriftBuster.Gui/App.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using DriftBuster.Gui.Headless;
+using DriftBuster.Gui.Services;
 using DriftBuster.Gui.ViewModels;
 using DriftBuster.Gui.Views;
 
@@ -15,6 +16,10 @@ namespace DriftBuster.Gui
     [ExcludeFromCodeCoverage]
     public partial class App : Application
     {
+#if DEBUG
+        private AutomationServer? _automationServer;
+#endif
+
         public override void Initialize()
         {
             AvaloniaXamlLoader.Load(this);
@@ -27,6 +32,16 @@ namespace DriftBuster.Gui
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
                 desktop.MainWindow = CreateMainWindowWithFontFallback();
+
+#if DEBUG
+                if (string.Equals(Environment.GetEnvironmentVariable("DRIFTBUSTER_AUTOMATION"), "1", StringComparison.Ordinal))
+                {
+                    var mainVm = (MainWindowViewModel)desktop.MainWindow.DataContext!;
+                    _automationServer = new AutomationServer(new AutomationDispatcher(mainVm));
+                    _automationServer.Start();
+                    desktop.ShutdownRequested += (_, _) => _automationServer?.Dispose();
+                }
+#endif
             }
 
             base.OnFrameworkInitializationCompleted();

--- a/gui/DriftBuster.Gui/Services/AutomationDispatcher.cs
+++ b/gui/DriftBuster.Gui/Services/AutomationDispatcher.cs
@@ -1,0 +1,330 @@
+#if DEBUG
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+using DriftBuster.Backend.Models;
+using DriftBuster.Gui.ViewModels;
+
+namespace DriftBuster.Gui.Services;
+
+/// <summary>
+/// Routes JSON automation commands to ViewModel methods.
+/// All public methods are called on the Avalonia UI thread.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal sealed class AutomationDispatcher
+{
+    private readonly MainWindowViewModel _mainVm;
+    private ServerSelectionViewModel? _serverVm;
+
+    public AutomationDispatcher(MainWindowViewModel mainVm)
+    {
+        _mainVm = mainVm ?? throw new ArgumentNullException(nameof(mainVm));
+    }
+
+    public string Dispatch(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("cmd", out var cmdElement))
+            {
+                return AutomationState.Serialize(AutomationState.ErrorResponse("Missing 'cmd' property."));
+            }
+
+            var cmd = cmdElement.GetString() ?? string.Empty;
+            var result = cmd switch
+            {
+                "ping" => HandlePing(),
+                "get-state" => HandleGetState(),
+                "navigate" => HandleNavigate(root),
+                "set-enabled" => HandleSetEnabled(root),
+                "set-scope" => HandleSetScope(root),
+                "set-label" => HandleSetLabel(root),
+                "add-root" => HandleAddRoot(root),
+                "remove-root" => HandleRemoveRoot(root),
+                "run-all" => HandleRunAll(),
+                "run-missing" => HandleRunMissing(),
+                "cancel" => HandleCancel(),
+                "clear-history" => HandleClearHistory(),
+                "get-catalog" => HandleGetCatalog(),
+                "get-activity" => HandleGetActivity(),
+                "get-drilldown" => HandleGetDrilldown(root),
+                _ => AutomationState.ErrorResponse($"Unknown command: {cmd}"),
+            };
+
+            return AutomationState.Serialize(result);
+        }
+        catch (JsonException ex)
+        {
+            return AutomationState.Serialize(AutomationState.ErrorResponse($"Invalid JSON: {ex.Message}"));
+        }
+        catch (Exception ex)
+        {
+            return AutomationState.Serialize(AutomationState.ErrorResponse($"{ex.GetType().Name}: {ex.Message}"));
+        }
+    }
+
+    private ServerSelectionViewModel? GetServerVm()
+    {
+        // Always re-probe CurrentView to avoid holding a stale reference
+        // when the user navigates via the GUI (bypassing automation commands).
+        if (_mainVm.CurrentView is Avalonia.Controls.Control control &&
+            control.DataContext is ServerSelectionViewModel vm)
+        {
+            _serverVm = vm;
+            return vm;
+        }
+
+        // Fall back to cached reference if CurrentView has changed away
+        // but we still need to read from the last known multi-server VM.
+        return _serverVm;
+    }
+
+    private ServerSelectionViewModel RequireServerVm()
+    {
+        return GetServerVm() ?? throw new InvalidOperationException("Navigate to multi-server tab first.");
+    }
+
+    private static int GetSlotIndex(JsonElement root)
+    {
+        if (!root.TryGetProperty("slot", out var slotEl))
+        {
+            throw new ArgumentException("Missing 'slot' property.", nameof(root));
+        }
+
+        return slotEl.GetInt32();
+    }
+
+    private ServerSlotViewModel GetSlot(JsonElement root)
+    {
+        var vm = RequireServerVm();
+        var index = GetSlotIndex(root);
+        if (index < 0 || index >= vm.Servers.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(root), $"Slot index {index} out of range (0..{vm.Servers.Count - 1}).");
+        }
+
+        return vm.Servers[index];
+    }
+
+    private Dictionary<string, object?> HandlePing()
+    {
+        return AutomationState.OkResponse(new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["pid"] = Environment.ProcessId,
+        });
+    }
+
+    private Dictionary<string, object?> HandleGetState()
+    {
+        var serverVm = GetServerVm();
+        var state = AutomationState.SnapshotState(_mainVm, serverVm);
+        return AutomationState.OkResponse(state);
+    }
+
+    private Dictionary<string, object?> HandleNavigate(JsonElement root)
+    {
+        if (!root.TryGetProperty("tab", out var tabEl))
+        {
+            return AutomationState.ErrorResponse("Missing 'tab' property.");
+        }
+
+        var tab = (tabEl.GetString() ?? string.Empty).Trim().ToLowerInvariant();
+        switch (tab)
+        {
+            case "diff":
+                _mainVm.ShowDiff();
+                _serverVm = null;
+                break;
+            case "hunt":
+                _mainVm.ShowHunt();
+                _serverVm = null;
+                break;
+            case "profiles":
+                _mainVm.ShowProfiles();
+                _serverVm = null;
+                break;
+            case "multi-server":
+            case "multiserver":
+                _mainVm.ShowMultiServer();
+                _serverVm = null;
+                break;
+            default:
+                return AutomationState.ErrorResponse($"Unknown tab: {tab}. Valid: diff, hunt, profiles, multi-server.");
+        }
+
+        return AutomationState.OkResponse();
+    }
+
+    private Dictionary<string, object?> HandleSetEnabled(JsonElement root)
+    {
+        var slot = GetSlot(root);
+        if (!root.TryGetProperty("enabled", out var enabledEl))
+        {
+            return AutomationState.ErrorResponse("Missing 'enabled' property.");
+        }
+
+        slot.IsEnabled = enabledEl.GetBoolean();
+        return AutomationState.OkResponse(AutomationState.SnapshotSlot(slot));
+    }
+
+    private Dictionary<string, object?> HandleSetScope(JsonElement root)
+    {
+        var slot = GetSlot(root);
+        if (!root.TryGetProperty("scope", out var scopeEl))
+        {
+            return AutomationState.ErrorResponse("Missing 'scope' property.");
+        }
+
+        var scopeStr = scopeEl.GetString() ?? string.Empty;
+        if (!Enum.TryParse<ServerScanScope>(scopeStr, ignoreCase: true, out var scope))
+        {
+            return AutomationState.ErrorResponse($"Invalid scope: {scopeStr}. Valid: AllDrives, SingleDrive, CustomRoots.");
+        }
+
+        slot.Scope = scope;
+        return AutomationState.OkResponse(AutomationState.SnapshotSlot(slot));
+    }
+
+    private Dictionary<string, object?> HandleSetLabel(JsonElement root)
+    {
+        var slot = GetSlot(root);
+        if (!root.TryGetProperty("label", out var labelEl))
+        {
+            return AutomationState.ErrorResponse("Missing 'label' property.");
+        }
+
+        slot.Label = labelEl.GetString() ?? string.Empty;
+        return AutomationState.OkResponse(AutomationState.SnapshotSlot(slot));
+    }
+
+    private Dictionary<string, object?> HandleAddRoot(JsonElement root)
+    {
+        var vm = RequireServerVm();
+        var slot = GetSlot(root);
+        if (!root.TryGetProperty("path", out var pathEl))
+        {
+            return AutomationState.ErrorResponse("Missing 'path' property.");
+        }
+
+        slot.NewRootPath = pathEl.GetString() ?? string.Empty;
+        vm.AddRootCommand.Execute(slot);
+        return AutomationState.OkResponse(AutomationState.SnapshotSlot(slot));
+    }
+
+    private Dictionary<string, object?> HandleRemoveRoot(JsonElement root)
+    {
+        var vm = RequireServerVm();
+        var slot = GetSlot(root);
+        if (!root.TryGetProperty("index", out var indexEl))
+        {
+            return AutomationState.ErrorResponse("Missing 'index' property.");
+        }
+
+        var rootIndex = indexEl.GetInt32();
+        if (rootIndex < 0 || rootIndex >= slot.Roots.Count)
+        {
+            return AutomationState.ErrorResponse($"Root index {rootIndex} out of range (0..{slot.Roots.Count - 1}).");
+        }
+
+        vm.RemoveRootCommand.Execute(slot.Roots[rootIndex]);
+        return AutomationState.OkResponse(AutomationState.SnapshotSlot(slot));
+    }
+
+    private Dictionary<string, object?> HandleRunAll()
+    {
+        var vm = RequireServerVm();
+        if (!vm.RunAllCommand.CanExecute(null))
+        {
+            return AutomationState.ErrorResponse("RunAll not available (busy or no active servers).");
+        }
+
+        _ = vm.RunAllCommand.ExecuteAsync(null);
+        return AutomationState.OkResponse(new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["planCount"] = vm.Servers.Count(s => s.IsEnabled),
+        });
+    }
+
+    private Dictionary<string, object?> HandleRunMissing()
+    {
+        var vm = RequireServerVm();
+        if (!vm.RunMissingCommand.CanExecute(null))
+        {
+            return AutomationState.ErrorResponse("RunMissing not available.");
+        }
+
+        _ = vm.RunMissingCommand.ExecuteAsync(null);
+        return AutomationState.OkResponse();
+    }
+
+    private Dictionary<string, object?> HandleCancel()
+    {
+        var vm = RequireServerVm();
+        if (vm.CancelRunsCommand.CanExecute(null))
+        {
+            vm.CancelRunsCommand.Execute(null);
+        }
+
+        return AutomationState.OkResponse();
+    }
+
+    private Dictionary<string, object?> HandleClearHistory()
+    {
+        var vm = RequireServerVm();
+        vm.ClearHistoryCommand.Execute(null);
+        return AutomationState.OkResponse();
+    }
+
+    private Dictionary<string, object?> HandleGetCatalog()
+    {
+        var vm = RequireServerVm();
+        var entries = AutomationState.SnapshotCatalog(vm.CatalogViewModel);
+        return AutomationState.OkResponse(entries);
+    }
+
+    private Dictionary<string, object?> HandleGetActivity()
+    {
+        var vm = RequireServerVm();
+        var entries = AutomationState.SnapshotActivity(vm.FilteredActivityEntries);
+        return AutomationState.OkResponse(entries);
+    }
+
+    private Dictionary<string, object?> HandleGetDrilldown(JsonElement root)
+    {
+        var vm = RequireServerVm();
+        if (!root.TryGetProperty("hostId", out var hostIdEl))
+        {
+            return AutomationState.ErrorResponse("Missing 'hostId' property.");
+        }
+
+        var hostId = hostIdEl.GetString() ?? string.Empty;
+        if (!vm.ShowDrilldownForHostCommand.CanExecute(hostId))
+        {
+            return AutomationState.ErrorResponse($"Cannot show drilldown for host '{hostId}'.");
+        }
+
+        vm.ShowDrilldownForHostCommand.Execute(hostId);
+
+        if (vm.DrilldownViewModel is null)
+        {
+            return AutomationState.ErrorResponse("Drilldown not available after navigation.");
+        }
+
+        var drilldown = vm.DrilldownViewModel;
+        return AutomationState.OkResponse(new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["configId"] = drilldown.ConfigId,
+            ["displayName"] = drilldown.DisplayName,
+            ["format"] = drilldown.Format,
+            ["driftCount"] = drilldown.DriftCount,
+            ["hasSecrets"] = drilldown.HasSecrets,
+            ["baselineHostId"] = drilldown.BaselineHostId,
+            ["baselineLabel"] = drilldown.BaselineLabel,
+        });
+    }
+}
+#endif

--- a/gui/DriftBuster.Gui/Services/AutomationDispatcher.cs
+++ b/gui/DriftBuster.Gui/Services/AutomationDispatcher.cs
@@ -132,8 +132,10 @@ internal sealed class AutomationDispatcher
             return AutomationState.ErrorResponse("Missing 'tab' property.");
         }
 
-        var tab = (tabEl.GetString() ?? string.Empty).Trim().ToLowerInvariant();
-        switch (tab)
+        var tab = tabEl.GetString() ?? string.Empty;
+        var (section, subView) = ParseNavigationTarget(tab);
+
+        switch (section)
         {
             case "diff":
                 _mainVm.ShowDiff();
@@ -151,12 +153,66 @@ internal sealed class AutomationDispatcher
             case "multiserver":
                 _mainVm.ShowMultiServer();
                 _serverVm = null;
-                break;
+                return NavigateMultiServerSubView(subView);
             default:
-                return AutomationState.ErrorResponse($"Unknown tab: {tab}. Valid: diff, hunt, profiles, multi-server.");
+                return AutomationState.ErrorResponse(
+                    $"Unknown tab: {tab}. Valid: diff, hunt, profiles, multi-server, multi-server/setup, multi-server/catalog, multi-server/drilldown.");
         }
 
         return AutomationState.OkResponse();
+    }
+
+    private static (string Section, string? SubView) ParseNavigationTarget(string tab)
+    {
+        var normalized = tab.Trim().ToLowerInvariant();
+        if (normalized.StartsWith("multi-server/", StringComparison.Ordinal))
+        {
+            return ("multi-server", normalized["multi-server/".Length..]);
+        }
+
+        if (normalized.StartsWith("multiserver/", StringComparison.Ordinal))
+        {
+            return ("multi-server", normalized["multiserver/".Length..]);
+        }
+
+        return (normalized, null);
+    }
+
+    private Dictionary<string, object?> NavigateMultiServerSubView(string? subView)
+    {
+        if (string.IsNullOrWhiteSpace(subView))
+        {
+            return AutomationState.OkResponse();
+        }
+
+        var vm = RequireServerVm();
+        var target = subView.Trim();
+
+        switch (target)
+        {
+            case "setup":
+                vm.ShowSetupCommand.Execute(null);
+                return AutomationState.OkResponse();
+            case "catalog":
+                if (!vm.ShowCatalogCommand.CanExecute(null))
+                {
+                    return AutomationState.ErrorResponse("Catalog view is unavailable (no catalog entries).");
+                }
+
+                vm.ShowCatalogCommand.Execute(null);
+                return AutomationState.OkResponse();
+            case "drilldown":
+                if (!vm.ShowDrilldownCommand.CanExecute(null))
+                {
+                    return AutomationState.ErrorResponse("Drilldown view is unavailable (no drilldown loaded).");
+                }
+
+                vm.ShowDrilldownCommand.Execute(null);
+                return AutomationState.OkResponse();
+            default:
+                return AutomationState.ErrorResponse(
+                    $"Unknown multi-server sub-view: {subView}. Valid: setup, catalog, drilldown.");
+        }
     }
 
     private Dictionary<string, object?> HandleSetEnabled(JsonElement root)

--- a/gui/DriftBuster.Gui/Services/AutomationServer.cs
+++ b/gui/DriftBuster.Gui/Services/AutomationServer.cs
@@ -1,5 +1,6 @@
 #if DEBUG
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO.Pipes;
 
 using Avalonia.Threading;
@@ -14,16 +15,21 @@ namespace DriftBuster.Gui.Services;
 [ExcludeFromCodeCoverage]
 internal sealed class AutomationServer : IDisposable
 {
+    internal const string UiDispatchTimeoutMsVariable = "DRIFTBUSTER_AUTOMATION_UI_DISPATCH_TIMEOUT_MS";
+    internal static readonly TimeSpan DefaultUiDispatchTimeout = TimeSpan.FromSeconds(30);
+
     private readonly AutomationDispatcher _dispatcher;
     private readonly string _pipeName;
+    private readonly TimeSpan _uiDispatchTimeout;
     private readonly CancellationTokenSource _cts = new();
     private Task? _listenTask;
     private bool _disposed;
 
-    public AutomationServer(AutomationDispatcher dispatcher)
+    public AutomationServer(AutomationDispatcher dispatcher, TimeSpan? uiDispatchTimeout = null)
     {
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _pipeName = $"DriftBuster-Automation-{Environment.ProcessId}";
+        _uiDispatchTimeout = uiDispatchTimeout ?? ParseUiDispatchTimeout(Environment.GetEnvironmentVariable(UiDispatchTimeoutMsVariable));
     }
 
     public string PipeName => _pipeName;
@@ -122,31 +128,99 @@ internal sealed class AutomationServer : IDisposable
 
             DebugLog.Trace("AutomationServer", "Command received", new { Command = trimmed });
 
-            string response;
-            try
-            {
-                response = await Dispatcher.UIThread.InvokeAsync(() => _dispatcher.Dispatch(trimmed));
-            }
-            catch (Exception ex)
-            {
-                response = AutomationState.Serialize(AutomationState.ErrorResponse($"Dispatch error: {ex.Message}"));
-            }
-
-            DebugLog.Trace("AutomationServer", "Response sent", new { Response = response });
-
-            try
-            {
-                await writer.WriteLineAsync(response.AsMemory(), ct).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-            catch
+            if (!await ProcessCommandAsync(trimmed, writer, ct).ConfigureAwait(false))
             {
                 break;
             }
         }
+    }
+
+    private async Task<bool> ProcessCommandAsync(string command, StreamWriter writer, CancellationToken ct)
+    {
+        var response = await BuildResponseAsync(command, ct).ConfigureAwait(false);
+        if (response is null)
+        {
+            return false;
+        }
+
+        DebugLog.Trace("AutomationServer", "Response sent", new { Response = response });
+
+        try
+        {
+            await writer.WriteLineAsync(response.AsMemory(), ct).ConfigureAwait(false);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async Task<string?> BuildResponseAsync(string command, CancellationToken ct)
+    {
+        try
+        {
+            return await DispatchWithTimeoutAsync(
+                async () => await Dispatcher.UIThread.InvokeAsync(() => _dispatcher.Dispatch(command)),
+                _uiDispatchTimeout,
+                ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return AutomationState.Serialize(AutomationState.ErrorResponse($"Dispatch error: {ex.Message}"));
+        }
+    }
+
+    internal static async Task<string> DispatchWithTimeoutAsync(
+        Func<Task<string>> dispatchAsync,
+        TimeSpan timeout,
+        CancellationToken ct)
+    {
+        if (dispatchAsync is null)
+        {
+            throw new ArgumentNullException(nameof(dispatchAsync));
+        }
+
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be greater than zero.");
+        }
+
+        var dispatchTask = dispatchAsync();
+        var timeoutTask = Task.Delay(timeout, ct);
+        var completedTask = await Task.WhenAny(dispatchTask, timeoutTask).ConfigureAwait(false);
+
+        if (ct.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(ct);
+        }
+
+        if (completedTask == dispatchTask)
+        {
+            return await dispatchTask.ConfigureAwait(false);
+        }
+
+        return AutomationState.Serialize(AutomationState.ErrorResponse(
+            $"UI thread dispatch timed out after {timeout.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture)}s."));
+    }
+
+    internal static TimeSpan ParseUiDispatchTimeout(string? candidate)
+    {
+        if (int.TryParse(candidate, NumberStyles.Integer, CultureInfo.InvariantCulture, out var milliseconds) &&
+            milliseconds > 0)
+        {
+            return TimeSpan.FromMilliseconds(milliseconds);
+        }
+
+        return DefaultUiDispatchTimeout;
     }
 
     public void Dispose()

--- a/gui/DriftBuster.Gui/Services/AutomationServer.cs
+++ b/gui/DriftBuster.Gui/Services/AutomationServer.cs
@@ -1,0 +1,175 @@
+#if DEBUG
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Pipes;
+
+using Avalonia.Threading;
+
+namespace DriftBuster.Gui.Services;
+
+/// <summary>
+/// Named pipe RPC server for GUI automation.
+/// Listens on <c>DriftBuster-Automation-{PID}</c> for newline-delimited JSON commands.
+/// Single client at a time; reconnects automatically when the client disconnects.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal sealed class AutomationServer : IDisposable
+{
+    private readonly AutomationDispatcher _dispatcher;
+    private readonly string _pipeName;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _listenTask;
+    private bool _disposed;
+
+    public AutomationServer(AutomationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _pipeName = $"DriftBuster-Automation-{Environment.ProcessId}";
+    }
+
+    public string PipeName => _pipeName;
+
+    public void Start()
+    {
+        if (_listenTask is not null)
+        {
+            return;
+        }
+
+        _listenTask = Task.Run(() => ListenLoopAsync(_cts.Token));
+        DebugLog.Trace("AutomationServer", "Started", new { PipeName = _pipeName });
+    }
+
+    private async Task ListenLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            NamedPipeServerStream? pipe = null;
+            try
+            {
+                pipe = new NamedPipeServerStream(
+                    _pipeName,
+                    PipeDirection.InOut,
+                    1,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous);
+
+                await pipe.WaitForConnectionAsync(ct).ConfigureAwait(false);
+                DebugLog.Trace("AutomationServer", "Client connected");
+
+                await HandleClientAsync(pipe, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Trace("AutomationServer", "ListenLoop error", new { Error = ex.Message });
+            }
+            finally
+            {
+                if (pipe is not null)
+                {
+                    try
+                    {
+                        if (pipe.IsConnected)
+                        {
+                            pipe.Disconnect();
+                        }
+                    }
+                    catch
+                    {
+                        // Best-effort disconnect.
+                    }
+
+                    await pipe.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    private async Task HandleClientAsync(NamedPipeServerStream pipe, CancellationToken ct)
+    {
+        using var reader = new StreamReader(pipe, leaveOpen: true);
+        using var writer = new StreamWriter(pipe, leaveOpen: true) { AutoFlush = true };
+
+        while (!ct.IsCancellationRequested && pipe.IsConnected)
+        {
+            string? line;
+            try
+            {
+                line = await reader.ReadLineAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                break;
+            }
+
+            if (line is null)
+            {
+                break;
+            }
+
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
+            DebugLog.Trace("AutomationServer", "Command received", new { Command = trimmed });
+
+            string response;
+            try
+            {
+                response = await Dispatcher.UIThread.InvokeAsync(() => _dispatcher.Dispatch(trimmed));
+            }
+            catch (Exception ex)
+            {
+                response = AutomationState.Serialize(AutomationState.ErrorResponse($"Dispatch error: {ex.Message}"));
+            }
+
+            DebugLog.Trace("AutomationServer", "Response sent", new { Response = response });
+
+            try
+            {
+                await writer.WriteLineAsync(response.AsMemory(), ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                break;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _cts.Cancel();
+
+        try
+        {
+            _listenTask?.Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+            // Shutdown timeout — acceptable.
+        }
+
+        _cts.Dispose();
+        DebugLog.Trace("AutomationServer", "Disposed");
+    }
+}
+#endif

--- a/gui/DriftBuster.Gui/Services/AutomationState.cs
+++ b/gui/DriftBuster.Gui/Services/AutomationState.cs
@@ -1,0 +1,117 @@
+#if DEBUG
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using DriftBuster.Gui.ViewModels;
+
+namespace DriftBuster.Gui.Services;
+
+/// <summary>
+/// Snapshots ViewModel state into JSON-serializable DTOs for the automation pipe.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class AutomationState
+{
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    public static string Serialize(object value) =>
+        JsonSerializer.Serialize(value, s_options);
+
+    public static Dictionary<string, object?> SnapshotState(MainWindowViewModel mainVm, ServerSelectionViewModel? serverVm)
+    {
+        var state = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["activeTab"] = mainVm.ActiveView.ToString().ToLowerInvariant(),
+        };
+
+        if (serverVm is not null)
+        {
+            state["isBusy"] = serverVm.IsBusy;
+            state["statusBanner"] = serverVm.StatusBanner;
+            state["isViewingCatalog"] = serverVm.IsViewingCatalog;
+            state["isViewingDrilldown"] = serverVm.IsViewingDrilldown;
+            state["hasCatalogEntries"] = serverVm.CatalogViewModel.HasEntries;
+            state["slots"] = serverVm.Servers.Select(SnapshotSlot).ToArray();
+        }
+
+        return state;
+    }
+
+    public static Dictionary<string, object?> SnapshotSlot(ServerSlotViewModel slot)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["index"] = slot.Index,
+            ["hostId"] = slot.HostId,
+            ["label"] = slot.Label,
+            ["isEnabled"] = slot.IsEnabled,
+            ["scope"] = slot.Scope.ToString(),
+            ["runState"] = slot.RunState.ToString(),
+            ["statusText"] = slot.StatusText,
+            ["validationSummary"] = slot.ValidationSummary,
+            ["roots"] = slot.Roots.Select(r => new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["path"] = r.Path,
+                ["validationState"] = r.ValidationState.ToString(),
+                ["statusMessage"] = r.StatusMessage,
+            }).ToArray(),
+        };
+    }
+
+    public static object[] SnapshotCatalog(ResultsCatalogViewModel catalog)
+    {
+        return catalog.FilteredEntries.Select(entry => (object)new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["configId"] = entry.ConfigId,
+            ["displayName"] = entry.DisplayName,
+            ["format"] = entry.Format,
+            ["driftCount"] = entry.DriftCount,
+            ["severity"] = entry.Severity,
+            ["coverageText"] = entry.CoverageText,
+            ["coverageStatus"] = entry.CoverageStatus,
+            ["hasSecrets"] = entry.HasSecrets,
+            ["hasValidationIssues"] = entry.HasValidationIssues,
+            ["presentHosts"] = entry.PresentHosts,
+            ["missingHosts"] = entry.MissingHosts,
+        }).ToArray();
+    }
+
+    public static object[] SnapshotActivity(IEnumerable<ActivityEntryViewModel> entries)
+    {
+        return entries.Select(entry => (object)new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["severity"] = entry.Severity.ToString(),
+            ["summary"] = entry.Summary,
+            ["detail"] = entry.Detail,
+            ["timestamp"] = entry.Timestamp,
+            ["category"] = entry.Category.ToString(),
+        }).ToArray();
+    }
+
+    public static Dictionary<string, object?> OkResponse(object? data = null)
+    {
+        var response = new Dictionary<string, object?>(StringComparer.Ordinal) { ["ok"] = true };
+        if (data is not null)
+        {
+            response["data"] = data;
+        }
+
+        return response;
+    }
+
+    public static Dictionary<string, object?> ErrorResponse(string message)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["ok"] = false,
+            ["error"] = message,
+        };
+    }
+}
+#endif

--- a/gui/DriftBuster.Gui/Services/DebugFileLogger.cs
+++ b/gui/DriftBuster.Gui/Services/DebugFileLogger.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+
+using DriftBuster.Backend;
+
+namespace DriftBuster.Gui.Services;
+
+/// <summary>
+/// Appending JSONL debug logger for diagnosing GUI interaction issues.
+/// Each entry is one JSON line, suitable for <c>tail -f</c> monitoring.
+/// Thread-safe, capped at ~10 MB per session to prevent disk fill.
+/// </summary>
+public sealed class DebugFileLogger
+{
+    private const long MaxFileSizeBytes = 10 * 1024 * 1024;
+
+    private readonly string _path;
+    private readonly Lock _syncRoot = new();
+    private readonly JsonSerializerOptions _serializerOptions;
+    private bool _capReached;
+
+    public DebugFileLogger(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("File path must be provided.", nameof(path));
+        }
+
+        _path = path;
+        _serializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+    }
+
+    public void Write(string category, string message, object? detail = null)
+    {
+        if (_capReached)
+        {
+            return;
+        }
+
+        var entry = new DebugLogEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Category = category,
+            Message = message,
+            Detail = detail,
+        };
+
+        string line;
+        try
+        {
+            line = JsonSerializer.Serialize(entry, _serializerOptions);
+        }
+        catch
+        {
+            // Serialization failure must never crash the app.
+            return;
+        }
+
+        lock (_syncRoot)
+        {
+            if (_capReached)
+            {
+                return;
+            }
+
+            try
+            {
+                var directory = Path.GetDirectoryName(_path);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                using var stream = new FileStream(_path, FileMode.Append, FileAccess.Write, FileShare.Read);
+                if (stream.Length > MaxFileSizeBytes)
+                {
+                    _capReached = true;
+                    return;
+                }
+
+                using var writer = new StreamWriter(stream);
+                writer.WriteLine(line);
+            }
+            catch
+            {
+                // Logging failures must never crash the app.
+            }
+        }
+    }
+
+    public static string DefaultLogPath()
+    {
+        return Path.Combine(DriftbusterPaths.GetDataRoot(), "logs", "debug.jsonl");
+    }
+
+    private sealed class DebugLogEntry
+    {
+        public DateTimeOffset Timestamp { get; init; }
+
+        public string Category { get; init; } = string.Empty;
+
+        public string Message { get; init; } = string.Empty;
+
+        public object? Detail { get; init; }
+    }
+}

--- a/gui/DriftBuster.Gui/Services/DebugLog.cs
+++ b/gui/DriftBuster.Gui/Services/DebugLog.cs
@@ -1,0 +1,30 @@
+namespace DriftBuster.Gui.Services;
+
+/// <summary>
+/// Static convenience accessor for the debug JSONL logger.
+/// Enabled when <c>DRIFTBUSTER_DEBUG=1</c> is set.
+/// Call <see cref="Trace"/> from anywhere without constructor injection.
+/// </summary>
+public static class DebugLog
+{
+    private static readonly bool s_enabled =
+        string.Equals(
+            Environment.GetEnvironmentVariable("DRIFTBUSTER_DEBUG"),
+            "1",
+            StringComparison.Ordinal);
+
+    private static readonly Lazy<DebugFileLogger> s_logger =
+        new(() => new DebugFileLogger(DebugFileLogger.DefaultLogPath()));
+
+    public static bool IsEnabled => s_enabled;
+
+    public static void Trace(string category, string message, object? detail = null)
+    {
+        if (!s_enabled)
+        {
+            return;
+        }
+
+        s_logger.Value.Write(category, message, detail);
+    }
+}

--- a/gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs
+++ b/gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs
@@ -96,6 +96,8 @@ namespace DriftBuster.Gui.ViewModels
             {
                 SelectedTheme = _themeRuntime.GetDefaultTheme(ThemeOptions);
             }
+
+            DebugLog.Trace("MainWindow", "Initialized", new { DebugLog.IsEnabled });
         }
 
         public bool IsDiffSelected => ActiveView == MainViewSection.Diff;
@@ -108,24 +110,28 @@ namespace DriftBuster.Gui.ViewModels
 
         public void ShowDiff()
         {
+            DebugLog.Trace("MainWindow", "ShowDiff");
             ActiveView = MainViewSection.Diff;
             CurrentView = _diffViewFactory(_service);
         }
 
         public void ShowHunt(string? initial = null)
         {
+            DebugLog.Trace("MainWindow", "ShowHunt");
             ActiveView = MainViewSection.Hunt;
             CurrentView = _huntViewFactory(_service, initial);
         }
 
         public void ShowProfiles()
         {
+            DebugLog.Trace("MainWindow", "ShowProfiles");
             ActiveView = MainViewSection.Profiles;
             CurrentView = _profilesViewFactory(_service);
         }
 
         public void ShowMultiServer()
         {
+            DebugLog.Trace("MainWindow", "ShowMultiServer");
             ActiveView = MainViewSection.MultiServer;
             CurrentView = _serverSelectionFactory(_service, _toastService, _performanceProfile);
         }

--- a/gui/DriftBuster.Gui/ViewModels/ServerSelectionViewModel.cs
+++ b/gui/DriftBuster.Gui/ViewModels/ServerSelectionViewModel.cs
@@ -230,6 +230,7 @@ namespace DriftBuster.Gui.ViewModels
 
         internal void NotifyServerToggled(ServerSlotViewModel slot)
         {
+            DebugLog.Trace("ServerSelection", "NotifyServerToggled", new { slot.IsEnabled, slot.Label, slot.Index });
             OnPropertyChanged(nameof(HasActiveServers));
             RunAllCommand.NotifyCanExecuteChanged();
             RunMissingCommand.NotifyCanExecuteChanged();
@@ -238,6 +239,8 @@ namespace DriftBuster.Gui.ViewModels
 
         internal void NotifyScopeChanged(ServerSlotViewModel slot)
         {
+            DebugLog.Trace("ServerSelection", "NotifyScopeChanged", new { Scope = slot.Scope.ToString(), slot.Label, RootCount = slot.Roots.Count });
+
             if (slot.Scope == ServerScanScope.CustomRoots && slot.Roots.Count == 0)
             {
                 slot.EnsureDefaultRoot();
@@ -253,6 +256,7 @@ namespace DriftBuster.Gui.ViewModels
                 var result = ValidateRoot(slot, root);
                 root.ValidationState = result.State;
                 root.StatusMessage = result.Message;
+                DebugLog.Trace("ServerSelection", "RevalidateRoots", new { root.Path, State = result.State.ToString(), result.Message, slot.Label });
             }
 
             slot.RefreshValidationSummary();
@@ -272,13 +276,18 @@ namespace DriftBuster.Gui.ViewModels
 
         private async Task LoadSessionAsync()
         {
+            DebugLog.Trace("ServerSelection", "LoadSessionAsync start");
+
             try
             {
                 var snapshot = await _cacheService.LoadAsync().ConfigureAwait(false);
                 if (snapshot is null)
                 {
+                    DebugLog.Trace("ServerSelection", "LoadSessionAsync: no snapshot found");
                     return;
                 }
+
+                DebugLog.Trace("ServerSelection", "LoadSessionAsync: restoring", new { SlotCount = snapshot.Servers.Count, snapshot.PersistSession });
 
                 PersistSessionState = snapshot.PersistSession;
 
@@ -420,6 +429,8 @@ namespace DriftBuster.Gui.ViewModels
             }
 
             var candidate = (slot.NewRootPath ?? string.Empty).Trim();
+            DebugLog.Trace("ServerSelection", "OnAddRoot", new { Candidate = candidate, slot.Label, RootCount = slot.Roots.Count });
+
             if (string.IsNullOrEmpty(candidate))
             {
                 slot.RootInputError = "Enter a root path.";
@@ -442,6 +453,7 @@ namespace DriftBuster.Gui.ViewModels
             var result = ValidateRoot(slot, entry);
             entry.ValidationState = result.State;
             entry.StatusMessage = result.Message;
+            DebugLog.Trace("ServerSelection", "OnAddRoot validated", new { candidate, State = result.State.ToString(), result.Message, RootCountAfter = slot.Roots.Count });
             slot.RefreshValidationSummary();
         }
 
@@ -457,6 +469,8 @@ namespace DriftBuster.Gui.ViewModels
             {
                 return;
             }
+
+            DebugLog.Trace("ServerSelection", "OnRemoveRoot", new { entry.Path, slot.Label, RemainingRootCount = slot.Roots.Count });
 
             if (slot.Roots.Count <= 1)
             {
@@ -503,6 +517,11 @@ namespace DriftBuster.Gui.ViewModels
 
         private async Task ExecuteRunAsync(bool retryOnly, IReadOnlyCollection<string>? scopedHostIds = null)
         {
+            if (DebugLog.IsEnabled)
+            {
+                DebugLog.Trace("ServerSelection", "ExecuteRunAsync start", new { retryOnly, ActiveHostIds = ActiveServers.Select(s => s.HostId).ToArray(), ScopedHostIds = scopedHostIds });
+            }
+
             if (!HasActiveServers)
             {
                 StatusBanner = "Enable at least one server to run.";
@@ -566,6 +585,7 @@ namespace DriftBuster.Gui.ViewModels
             }
             catch (Exception ex)
             {
+                DebugLog.Trace("ServerSelection", "RunScans exception", new { ExceptionType = ex.GetType().Name, ex.Message, ex.StackTrace });
                 StatusBanner = $"Scan failed: {ex.Message}";
                 _toastService.Show(
                     "Multi-server scan failed",
@@ -586,11 +606,14 @@ namespace DriftBuster.Gui.ViewModels
 
         private void OnCancelRuns()
         {
+            DebugLog.Trace("ServerSelection", "OnCancelRuns", new { Timestamp = DateTimeOffset.UtcNow });
             _runCancellation?.Cancel();
         }
 
         private void OnClearHistory()
         {
+            DebugLog.Trace("ServerSelection", "OnClearHistory", new { EntryCount = _activityEntries.Count });
+
             foreach (var server in Servers)
             {
                 server.LastRunAt = null;
@@ -621,6 +644,8 @@ namespace DriftBuster.Gui.ViewModels
 
         private async Task SaveSessionAsync()
         {
+            DebugLog.Trace("ServerSelection", "SaveSessionAsync", new { PersistSessionState });
+
             if (!PersistSessionState)
             {
                 StatusBanner = "Enable session persistence to save.";
@@ -702,6 +727,8 @@ namespace DriftBuster.Gui.ViewModels
 
             foreach (var server in ActiveServers)
             {
+                TracePlanEvaluation(server);
+
                 if (scopedHostIds is not null && scopedHostIds.Count > 0)
                 {
                     var matchesHostId = scopedHostIds.Any(id => string.Equals(id, server.HostId, StringComparison.OrdinalIgnoreCase));
@@ -758,6 +785,8 @@ namespace DriftBuster.Gui.ViewModels
 
         private void UpdateProgress(ScanProgress progress)
         {
+            DebugLog.Trace("ServerSelection", "UpdateProgress", new { progress.HostId, Status = progress.Status.ToString(), progress.Message });
+
             var server = Servers.FirstOrDefault(slot => string.Equals(slot.HostId, progress.HostId, StringComparison.OrdinalIgnoreCase));
             if (server is null)
             {
@@ -946,6 +975,8 @@ namespace DriftBuster.Gui.ViewModels
 
         private void OnShowDrilldownForHost(string? hostId)
         {
+            DebugLog.Trace("ServerSelection", "ShowDrilldownForHost", new { HostId = hostId, HasDrilldown = _lastResponse?.Drilldown is not null });
+
             var target = TryValidateDrilldownHost(hostId);
             if (target is null)
             {
@@ -1203,6 +1234,8 @@ namespace DriftBuster.Gui.ViewModels
         private RootValidationResult ValidateRoot(ServerSlotViewModel slot, RootEntryViewModel entry)
         {
             var trimmed = (entry.Path ?? string.Empty).Trim();
+            DebugLog.Trace("ServerSelection", "ValidateRoot", new { Input = trimmed, slot.Label, Scope = slot.Scope.ToString() });
+
             if (string.IsNullOrEmpty(trimmed))
             {
                 return RootValidationResult.Invalid("Provide a root path.");
@@ -1220,6 +1253,7 @@ namespace DriftBuster.Gui.ViewModels
 
             if (_validationCache.TryGetValue(trimmed, out var cached))
             {
+                DebugLog.Trace("ServerSelection", "ValidateRoot cache hit", new { Input = trimmed, State = cached.State.ToString() });
                 return cached;
             }
 
@@ -1239,6 +1273,8 @@ namespace DriftBuster.Gui.ViewModels
             var result = exists
                 ? RootValidationResult.Valid("Ready")
                 : RootValidationResult.Invalid("Path not found.");
+
+            DebugLog.Trace("ServerSelection", "ValidateRoot result", new { Input = trimmed, State = result.State.ToString(), result.Message, Exists = exists });
 
             if (result.State == RootValidationState.Valid)
             {
@@ -1350,6 +1386,7 @@ namespace DriftBuster.Gui.ViewModels
 
         partial void OnIsBusyChanged(bool value)
         {
+            DebugLog.Trace("ServerSelection", "IsBusyChanged", new { IsBusy = value });
             RunAllCommand.NotifyCanExecuteChanged();
             RunMissingCommand.NotifyCanExecuteChanged();
             CancelRunsCommand.NotifyCanExecuteChanged();
@@ -1371,6 +1408,14 @@ namespace DriftBuster.Gui.ViewModels
                 {
                     IsViewingCatalog = false;
                 }
+            }
+        }
+
+        private static void TracePlanEvaluation(ServerSlotViewModel server)
+        {
+            if (DebugLog.IsEnabled)
+            {
+                DebugLog.Trace("ServerSelection", "PreparePlans evaluating", new { server.HostId, Scope = server.Scope.ToString(), Roots = server.Roots.Select(r => r.Path).ToArray(), IsBaseline = server.Index == 0 });
             }
         }
 

--- a/gui/DriftBuster.Gui/ViewModels/ServerSelectionViewModel.cs
+++ b/gui/DriftBuster.Gui/ViewModels/ServerSelectionViewModel.cs
@@ -675,19 +675,27 @@ namespace DriftBuster.Gui.ViewModels
 
         private ServerSelectionCache BuildSessionSnapshot()
         {
+            var sortDescriptor = CatalogViewModel.SortDescriptor;
             return new ServerSelectionCache
             {
                 SchemaVersion = SessionCacheService.CurrentSchemaVersion,
                 PersistSession = true,
-                Servers = Servers.Select(server => new ServerSelectionCacheEntry
-                {
-                    HostId = server.HostId,
-                    Label = server.Label,
-                    Enabled = server.IsEnabled,
-                    Scope = server.Scope,
-                    Roots = server.Roots.Select(root => root.Path).ToArray(),
-                }).ToList(),
+                Servers = Servers
+                    .Where(server => server is not null)
+                    .Select(server => new ServerSelectionCacheEntry
+                    {
+                        HostId = server.HostId,
+                        Label = server.Label,
+                        Enabled = server.IsEnabled,
+                        Scope = server.Scope,
+                        Roots = server.Roots
+                            .Where(root => root is not null && !string.IsNullOrWhiteSpace(root.Path))
+                            .Select(root => root.Path)
+                            .ToArray(),
+                    })
+                    .ToList(),
                 Activities = _activityEntries
+                    .Where(entry => entry is not null)
                     .Select(entry => new ActivityCacheEntry
                     {
                         Timestamp = entry.Timestamp,
@@ -699,8 +707,8 @@ namespace DriftBuster.Gui.ViewModels
                     .ToList(),
                 CatalogSort = new CatalogSortCache
                 {
-                    Column = CatalogViewModel.SortDescriptor.ColumnKey,
-                    Descending = CatalogViewModel.SortDescriptor.Descending,
+                    Column = sortDescriptor?.ColumnKey ?? CatalogSortColumns.Drift,
+                    Descending = sortDescriptor?.Descending ?? true,
                 },
                 ActivityFilter = ActivityFilter.ToString(),
                 CatalogFilters = new CatalogFilterCache

--- a/gui/DriftBuster.Gui/ViewModels/ServerSlotViewModel.cs
+++ b/gui/DriftBuster.Gui/ViewModels/ServerSlotViewModel.cs
@@ -82,6 +82,8 @@ namespace DriftBuster.Gui.ViewModels
 
         partial void OnIsEnabledChanged(bool value)
         {
+            DebugLog.Trace("ServerSlot", "OnIsEnabledChanged", new { IsEnabled = value, Label, Index });
+
             if (value)
             {
                 EnsureDefaultRoot();
@@ -98,11 +100,13 @@ namespace DriftBuster.Gui.ViewModels
 
         partial void OnScopeChanged(ServerScanScope value)
         {
+            DebugLog.Trace("ServerSlot", "OnScopeChanged", new { NewScope = value.ToString(), Label });
             _owner.NotifyScopeChanged(this);
         }
 
         public void MarkState(ServerScanStatus state, string statusText, DateTimeOffset? timestamp = null)
         {
+            DebugLog.Trace("ServerSlot", "MarkState", new { State = state.ToString(), StatusText = statusText, Label, Timestamp = timestamp });
             RunState = state;
             StatusText = statusText;
             if (state is ServerScanStatus.Succeeded or ServerScanStatus.Cached)
@@ -124,6 +128,7 @@ namespace DriftBuster.Gui.ViewModels
         internal void RefreshValidationSummary()
         {
             ValidationSummary = BuildValidationSummary();
+            DebugLog.Trace("ServerSlot", "RefreshValidationSummary", new { Summary = ValidationSummary, RootCount = Roots.Count, Label });
         }
 
         private string BuildValidationSummary()
@@ -167,6 +172,8 @@ namespace DriftBuster.Gui.ViewModels
 
         internal void EnsureDefaultRoot()
         {
+            DebugLog.Trace("ServerSlot", "EnsureDefaultRoot", new { CurrentRootCount = Roots.Count, Label });
+
             if (Roots.Count > 0)
             {
                 return;
@@ -187,11 +194,13 @@ namespace DriftBuster.Gui.ViewModels
 
         internal void AddRoot(RootEntryViewModel entry)
         {
+            DebugLog.Trace("ServerSlot", "AddRoot", new { entry.Path, Label, CountAfter = Roots.Count + 1 });
             Roots.Add(entry);
         }
 
         internal void RemoveRoot(RootEntryViewModel entry)
         {
+            DebugLog.Trace("ServerSlot", "RemoveRoot", new { entry.Path, Label, CountAfter = Roots.Count - 1 });
             Roots.Remove(entry);
         }
 
@@ -211,6 +220,10 @@ namespace DriftBuster.Gui.ViewModels
                 _suppressRootEvents = false;
             }
 
+            if (DebugLog.IsEnabled)
+            {
+                DebugLog.Trace("ServerSlot", "ReplaceRoots", new { Count = Roots.Count, Paths = Roots.Select(r => r.Path).ToArray(), Label });
+            }
             _owner.RevalidateRoots(this);
         }
 

--- a/scripts/coverage_history.py
+++ b/scripts/coverage_history.py
@@ -76,41 +76,50 @@ def append_history(
         "python_watch_min",
         "notes",
     ]
-
     existing_header: list[str] | None = None
+    existing_rows: list[list[str]] = []
     if output_path.exists():
         with output_path.open("r", encoding="utf-8", newline="") as fh:
             reader = csv.reader(fh)
             existing_header = next(reader, None)
+            existing_rows = list(reader)
+
+    if existing_header == legacy_header:
+        migrated_rows: list[list[str]] = []
+        for row in existing_rows:
+            padded = row + [""] * max(0, 5 - len(row))
+            migrated_rows.append(
+                [
+                    padded[0],
+                    padded[1],
+                    padded[2],
+                    "",
+                    padded[3],
+                    padded[4],
+                ]
+            )
+        with output_path.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(current_header)
+            writer.writerows(migrated_rows)
+        existing_header = current_header
 
     needs_header = existing_header is None
-    use_legacy_columns = existing_header == legacy_header
     with output_path.open("a", encoding="utf-8", newline="") as fh:
         writer = csv.writer(fh)
         if needs_header:
             writer.writerow(current_header)
 
-        if use_legacy_columns:
-            writer.writerow(
-                [
-                    timestamp,
-                    f"{python_percent:.2f}",
-                    "" if dotnet_percent is None else f"{dotnet_percent:.2f}",
-                    f"{watch_lowest:.2f}",
-                    notes or "",
-                ]
-            )
-        else:
-            writer.writerow(
-                [
-                    timestamp,
-                    f"{python_percent:.2f}",
-                    "" if dotnet_percent is None else f"{dotnet_percent:.2f}",
-                    "" if dotnet_changed_percent is None else f"{dotnet_changed_percent:.2f}",
-                    f"{watch_lowest:.2f}",
-                    notes or "",
-                ]
-            )
+        writer.writerow(
+            [
+                timestamp,
+                f"{python_percent:.2f}",
+                "" if dotnet_percent is None else f"{dotnet_percent:.2f}",
+                "" if dotnet_changed_percent is None else f"{dotnet_changed_percent:.2f}",
+                f"{watch_lowest:.2f}",
+                notes or "",
+            ]
+        )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/coverage_history.py
+++ b/scripts/coverage_history.py
@@ -8,8 +8,10 @@ from typing import Mapping
 
 from scripts.coverage_report import (
     find_cobertura_xml,
+    load_changed_production_lines,
     load_cobertura_summary,
     load_python_coverage,
+    summarise_changed_dotnet_lines,
 )
 from scripts.coverage_watch import (
     evaluate_watch_targets,
@@ -36,36 +38,79 @@ def compute_dotnet_percent(dotnet_root: Path) -> float | None:
     return line_rate * 100.0
 
 
+def compute_dotnet_changed_percent(dotnet_root: Path, diff_base: str) -> float | None:
+    xml_path = find_cobertura_xml(str(dotnet_root))
+    if xml_path is None:
+        return None
+
+    _line_rate, _classes, _files, line_hits = load_cobertura_summary(xml_path)
+    changed_lines = load_changed_production_lines(diff_base)
+    changed_ratio, _details, _skipped = summarise_changed_dotnet_lines(changed_lines, line_hits)
+    if changed_ratio is None:
+        return None
+    return changed_ratio * 100.0
+
+
 def append_history(
     output_path: Path,
     timestamp: str,
     python_percent: float,
     dotnet_percent: float | None,
+    dotnet_changed_percent: float | None,
     watch_lowest: float,
     notes: str | None,
 ) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    header = [
+    current_header = [
+        "timestamp_utc",
+        "python_percent",
+        "dotnet_percent",
+        "dotnet_changed_percent",
+        "python_watch_min",
+        "notes",
+    ]
+    legacy_header = [
         "timestamp_utc",
         "python_percent",
         "dotnet_percent",
         "python_watch_min",
         "notes",
     ]
-    needs_header = not output_path.exists()
+
+    existing_header: list[str] | None = None
+    if output_path.exists():
+        with output_path.open("r", encoding="utf-8", newline="") as fh:
+            reader = csv.reader(fh)
+            existing_header = next(reader, None)
+
+    needs_header = existing_header is None
+    use_legacy_columns = existing_header == legacy_header
     with output_path.open("a", encoding="utf-8", newline="") as fh:
         writer = csv.writer(fh)
         if needs_header:
-            writer.writerow(header)
-        writer.writerow(
-            [
-                timestamp,
-                f"{python_percent:.2f}",
-                "" if dotnet_percent is None else f"{dotnet_percent:.2f}",
-                f"{watch_lowest:.2f}",
-                notes or "",
-            ]
-        )
+            writer.writerow(current_header)
+
+        if use_legacy_columns:
+            writer.writerow(
+                [
+                    timestamp,
+                    f"{python_percent:.2f}",
+                    "" if dotnet_percent is None else f"{dotnet_percent:.2f}",
+                    f"{watch_lowest:.2f}",
+                    notes or "",
+                ]
+            )
+        else:
+            writer.writerow(
+                [
+                    timestamp,
+                    f"{python_percent:.2f}",
+                    "" if dotnet_percent is None else f"{dotnet_percent:.2f}",
+                    "" if dotnet_changed_percent is None else f"{dotnet_changed_percent:.2f}",
+                    f"{watch_lowest:.2f}",
+                    notes or "",
+                ]
+            )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -83,6 +128,11 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=Path("artifacts/coverage-dotnet"),
         help="Directory containing Cobertura XML output from .NET runs.",
+    )
+    parser.add_argument(
+        "--dotnet-diff-base",
+        default="origin/main",
+        help="Git base ref used for changed-line .NET coverage snapshots.",
     )
     parser.add_argument(
         "--output",
@@ -105,6 +155,7 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     dotnet_percent = compute_dotnet_percent(args.dotnet_root)
+    dotnet_changed_percent = compute_dotnet_changed_percent(args.dotnet_root, args.dotnet_diff_base)
     timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
     append_history(
@@ -112,6 +163,7 @@ def main(argv: list[str] | None = None) -> int:
         timestamp,
         python_percent,
         dotnet_percent,
+        dotnet_changed_percent,
         watch_lowest,
         args.notes,
     )
@@ -121,6 +173,12 @@ def main(argv: list[str] | None = None) -> int:
             "dotnet=N/A"
             if dotnet_percent is None
             else f"dotnet={dotnet_percent:.2f}%"
+        )
+        + " "
+        + (
+            "dotnet_changed=N/A"
+            if dotnet_changed_percent is None
+            else f"dotnet_changed={dotnet_changed_percent:.2f}%"
         )
         + f" watch_min={watch_lowest:.2f}%"
     )

--- a/scripts/coverage_history.py
+++ b/scripts/coverage_history.py
@@ -44,7 +44,10 @@ def compute_dotnet_changed_percent(dotnet_root: Path, diff_base: str) -> float |
         return None
 
     _line_rate, _classes, _files, line_hits = load_cobertura_summary(xml_path)
-    changed_lines = load_changed_production_lines(diff_base)
+    try:
+        changed_lines = load_changed_production_lines(diff_base)
+    except RuntimeError:
+        return None
     changed_ratio, _details, _skipped = summarise_changed_dotnet_lines(changed_lines, line_hits)
     if changed_ratio is None:
         return None

--- a/scripts/coverage_history.py
+++ b/scripts/coverage_history.py
@@ -32,7 +32,7 @@ def compute_dotnet_percent(dotnet_root: Path) -> float | None:
     xml_path = find_cobertura_xml(str(dotnet_root))
     if xml_path is None:
         return None
-    line_rate, _ = load_cobertura_summary(xml_path)
+    line_rate, *_ = load_cobertura_summary(xml_path)
     return line_rate * 100.0
 
 

--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -5,6 +5,7 @@ import glob
 import json
 import os
 import re
+import subprocess
 import sys
 import xml.etree.ElementTree as ET
 
@@ -26,22 +27,60 @@ def find_cobertura_xml(root: str = "artifacts/coverage-dotnet") -> str | None:
     return candidates[-1] if candidates else None
 
 
-def load_cobertura_summary(path: str) -> tuple[float, list[tuple[str, float]], list[tuple[str, int, int]]]:
+def coverage_path_candidates(path: str) -> set[str]:
+    normalised = normalise_coverage_path(path)
+    candidates = {normalised}
+
+    # Cobertura paths are typically project-relative (e.g. DriftBuster.Gui/...),
+    # while git diff uses repo-relative paths (e.g. gui/DriftBuster.Gui/...).
+    if normalised.startswith("DriftBuster."):
+        candidates.add(f"gui/{normalised}")
+
+    if os.path.isabs(normalised):
+        try:
+            rel = normalise_coverage_path(os.path.relpath(normalised, os.getcwd()))
+            if not rel.startswith("../"):
+                candidates.add(rel)
+        except ValueError:
+            pass
+
+    return candidates
+
+
+def load_cobertura_summary(path: str) -> tuple[
+    float,
+    list[tuple[str, float]],
+    list[tuple[str, int, int]],
+    dict[str, dict[int, int]],
+]:
     tree = ET.parse(path)
     root = tree.getroot()
     line_rate = float(root.attrib.get("line-rate", 0.0))
     classes: list[tuple[str, float]] = []
     files: list[tuple[str, int, int]] = []
+    line_hits: dict[str, dict[int, int]] = {}
     for cls in root.findall(".//class"):
         name = cls.attrib.get("filename") or cls.attrib.get("name") or "?"
         rate = float(cls.attrib.get("line-rate", 0.0))
         classes.append((name, rate))
-        lines = cls.findall(".//line")
+        lines = cls.findall("./lines/line")
         total = len(lines)
         hit = sum(1 for line in lines if int(line.attrib.get("hits", "0")) > 0)
         files.append((name, hit, total))
+
+        if not lines:
+            continue
+
+        for candidate in coverage_path_candidates(name):
+            index = line_hits.setdefault(candidate, {})
+            for line in lines:
+                number = int(line.attrib.get("number", "0"))
+                hits = int(line.attrib.get("hits", "0"))
+                existing = index.get(number)
+                if existing is None or hits > existing:
+                    index[number] = hits
     classes.sort(key=lambda x: x[1])
-    return line_rate, classes, files
+    return line_rate, classes, files, line_hits
 
 
 def normalise_coverage_path(path: str) -> str:
@@ -94,6 +133,92 @@ def summarise_scoped_dotnet(files: list[tuple[str, int, int]]) -> tuple[float, l
     return ratio, scoped
 
 
+def load_changed_production_lines(base_ref: str) -> dict[str, set[int]]:
+    try:
+        diff_output = subprocess.check_output(
+            ["git", "diff", "--unified=0", f"{base_ref}...HEAD", "--", "*.cs"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return {}
+
+    changed: dict[str, set[int]] = {}
+    current_file: str | None = None
+    for raw_line in diff_output.splitlines():
+        if raw_line.startswith("+++ "):
+            path = raw_line[4:].strip()
+            if path == "/dev/null":
+                current_file = None
+                continue
+            if path.startswith("b/"):
+                path = path[2:]
+
+            path = normalise_coverage_path(path)
+            if is_production_dotnet_source(path):
+                changed.setdefault(path, set())
+                current_file = path
+            else:
+                current_file = None
+            continue
+
+        if not raw_line.startswith("@@") or current_file is None:
+            continue
+
+        match = re.search(r"\+(\d+)(?:,(\d+))?", raw_line)
+        if match is None:
+            continue
+
+        start = int(match.group(1))
+        count = int(match.group(2) or "1")
+        if count == 0:
+            continue
+
+        for line_number in range(start, start + count):
+            changed[current_file].add(line_number)
+
+    return changed
+
+
+def summarise_changed_dotnet_lines(
+    changed_lines: dict[str, set[int]],
+    line_hits: dict[str, dict[int, int]],
+) -> tuple[float | None, list[tuple[str, int, int, float]], list[str]]:
+    details: list[tuple[str, int, int, float]] = []
+    skipped: list[str] = []
+    total_hit = 0
+    total_lines = 0
+
+    for file_path in sorted(changed_lines):
+        lines = changed_lines[file_path]
+        hits_index = line_hits.get(file_path)
+        if not hits_index:
+            skipped.append(file_path)
+            continue
+
+        executable = 0
+        covered = 0
+        for line_number in lines:
+            hits = hits_index.get(line_number)
+            if hits is None:
+                continue
+            executable += 1
+            if hits > 0:
+                covered += 1
+
+        if executable == 0:
+            skipped.append(file_path)
+            continue
+
+        total_hit += covered
+        total_lines += executable
+        details.append((file_path, covered, executable, covered / executable))
+
+    details.sort(key=lambda item: (item[3], -item[2], item[0]))
+    ratio = (total_hit / total_lines) if total_lines else None
+    return ratio, details, skipped
+
+
 def percent(v: float) -> str:
     return f"{v * 100:.2f}%"
 
@@ -103,8 +228,28 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--python-json", default="coverage.json")
     parser.add_argument("--dotnet-root", default="artifacts/coverage-dotnet")
     parser.add_argument("--top", type=int, default=5, help="Show top N most undercovered .NET classes")
-    parser.add_argument("--dotnet-threshold", type=float, default=90.0, help="Fail when scoped .NET coverage is below this percent.")
-    parser.add_argument("--enforce-dotnet-threshold", action="store_true", help="Return non-zero when scoped .NET coverage is below --dotnet-threshold.")
+    parser.add_argument(
+        "--dotnet-threshold",
+        type=float,
+        default=90.0,
+        help="Fail when the selected .NET coverage scope is below this percent.",
+    )
+    parser.add_argument(
+        "--dotnet-diff-base",
+        default="",
+        help="Optional git base ref for changed-line .NET coverage (for example: origin/main).",
+    )
+    parser.add_argument(
+        "--dotnet-enforce-scope",
+        choices=("scoped", "changed"),
+        default="scoped",
+        help="Coverage scope for --enforce-dotnet-threshold.",
+    )
+    parser.add_argument(
+        "--enforce-dotnet-threshold",
+        action="store_true",
+        help="Return non-zero when the selected .NET coverage scope is below --dotnet-threshold.",
+    )
     args = parser.parse_args(argv)
 
     py = load_python_coverage(args.python_json)
@@ -120,7 +265,7 @@ def main(argv: list[str] | None = None) -> int:
         print(".NET coverage: Cobertura XML not found")
         return 0
 
-    line_rate, classes, files = load_cobertura_summary(cob)
+    line_rate, classes, files, line_hits = load_cobertura_summary(cob)
     print(f".NET coverage (raw Cobertura): {percent(line_rate)}")
 
     scoped_rate, scoped_files = summarise_scoped_dotnet(files)
@@ -138,13 +283,51 @@ def main(argv: list[str] | None = None) -> int:
         for name, rate in undercovered[: args.top]:
             print(f"- {name}: {percent(rate)}")
 
+    changed_rate: float | None = None
+    if args.dotnet_diff_base:
+        changed_lines = load_changed_production_lines(args.dotnet_diff_base)
+        changed_rate, changed_files, changed_skipped = summarise_changed_dotnet_lines(changed_lines, line_hits)
+        covered = sum(item[1] for item in changed_files)
+        total = sum(item[2] for item in changed_files)
+        if changed_rate is None:
+            print(
+                f".NET coverage (changed production .cs executable lines vs {args.dotnet_diff_base}): "
+                "n/a (no executable changed lines)"
+            )
+        else:
+            print(
+                f".NET coverage (changed production .cs executable lines vs {args.dotnet_diff_base}): "
+                f"{percent(changed_rate)} ({covered}/{total})"
+            )
+        if changed_files:
+            print("Top undercovered changed .NET files:")
+            for name, hit, total_lines, rate in changed_files[: args.top]:
+                print(f"- {name}: {percent(rate)} ({hit}/{total_lines})")
+        if changed_skipped:
+            print(
+                f"Note: {len(changed_skipped)} changed file(s) had no executable coverage-mapped "
+                "lines (for example signature-only edits)."
+            )
+
     threshold_ratio = args.dotnet_threshold / 100.0
-    if args.enforce_dotnet_threshold and scoped_rate < threshold_ratio:
-        print(
-            f".NET scoped coverage check failed: {percent(scoped_rate)} "
-            f"is below required {args.dotnet_threshold:.2f}%."
-        )
-        return 1
+    if args.enforce_dotnet_threshold:
+        if args.dotnet_enforce_scope == "changed":
+            if changed_rate is None:
+                print(
+                    ".NET changed-line coverage check skipped: no executable changed production .cs lines found."
+                )
+            elif changed_rate < threshold_ratio:
+                print(
+                    f".NET changed-line coverage check failed: {percent(changed_rate)} "
+                    f"is below required {args.dotnet_threshold:.2f}%."
+                )
+                return 1
+        elif scoped_rate < threshold_ratio:
+            print(
+                f".NET scoped coverage check failed: {percent(scoped_rate)} "
+                f"is below required {args.dotnet_threshold:.2f}%."
+            )
+            return 1
 
     return 0
 

--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -265,6 +265,9 @@ def main(argv: list[str] | None = None) -> int:
     cob = find_cobertura_xml(args.dotnet_root)
     if cob is None:
         print(".NET coverage: Cobertura XML not found")
+        if args.enforce_dotnet_threshold:
+            print(".NET coverage check failed: Cobertura XML is required when enforcement is enabled.")
+            return 1
         return 0
 
     line_rate, classes, files, line_hits = load_cobertura_summary(cob)

--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -140,8 +140,10 @@ def load_changed_production_lines(base_ref: str) -> dict[str, set[int]]:
             text=True,
             stderr=subprocess.DEVNULL,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return {}
+    except FileNotFoundError as exc:
+        raise RuntimeError("git executable is not available") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"unable to compute git diff for base ref '{base_ref}'") from exc
 
     changed: dict[str, set[int]] = {}
     current_file: str | None = None
@@ -284,30 +286,45 @@ def main(argv: list[str] | None = None) -> int:
             print(f"- {name}: {percent(rate)}")
 
     changed_rate: float | None = None
+    changed_error: str | None = None
     if args.dotnet_diff_base:
-        changed_lines = load_changed_production_lines(args.dotnet_diff_base)
-        changed_rate, changed_files, changed_skipped = summarise_changed_dotnet_lines(changed_lines, line_hits)
-        covered = sum(item[1] for item in changed_files)
-        total = sum(item[2] for item in changed_files)
-        if changed_rate is None:
+        try:
+            changed_lines = load_changed_production_lines(args.dotnet_diff_base)
+        except RuntimeError as exc:
+            changed_error = str(exc)
             print(
                 f".NET coverage (changed production .cs executable lines vs {args.dotnet_diff_base}): "
-                "n/a (no executable changed lines)"
+                f"n/a ({changed_error})"
             )
         else:
-            print(
-                f".NET coverage (changed production .cs executable lines vs {args.dotnet_diff_base}): "
-                f"{percent(changed_rate)} ({covered}/{total})"
-            )
-        if changed_files:
-            print("Top undercovered changed .NET files:")
-            for name, hit, total_lines, rate in changed_files[: args.top]:
-                print(f"- {name}: {percent(rate)} ({hit}/{total_lines})")
-        if changed_skipped:
-            print(
-                f"Note: {len(changed_skipped)} changed file(s) had no executable coverage-mapped "
-                "lines (for example signature-only edits)."
-            )
+            changed_rate, changed_files, changed_skipped = summarise_changed_dotnet_lines(changed_lines, line_hits)
+            covered = sum(item[1] for item in changed_files)
+            total = sum(item[2] for item in changed_files)
+            if changed_rate is None:
+                print(
+                    f".NET coverage (changed production .cs executable lines vs {args.dotnet_diff_base}): "
+                    "n/a (no executable changed lines)"
+                )
+            else:
+                print(
+                    f".NET coverage (changed production .cs executable lines vs {args.dotnet_diff_base}): "
+                    f"{percent(changed_rate)} ({covered}/{total})"
+                )
+            if changed_files:
+                print("Top undercovered changed .NET files:")
+                for name, hit, total_lines, rate in changed_files[: args.top]:
+                    print(f"- {name}: {percent(rate)} ({hit}/{total_lines})")
+            if changed_skipped:
+                print(
+                    f"Note: {len(changed_skipped)} changed file(s) had no executable coverage-mapped "
+                    "lines (for example signature-only edits)."
+                )
+    elif args.dotnet_enforce_scope == "changed" and args.enforce_dotnet_threshold:
+        changed_error = "--dotnet-diff-base is required when enforcing changed scope"
+
+    if changed_error and args.enforce_dotnet_threshold and args.dotnet_enforce_scope == "changed":
+        print(f".NET changed-line coverage check failed: {changed_error}.")
+        return 1
 
     threshold_ratio = args.dotnet_threshold / 100.0
     if args.enforce_dotnet_threshold:

--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -4,6 +4,7 @@ import argparse
 import glob
 import json
 import os
+import re
 import sys
 import xml.etree.ElementTree as ET
 
@@ -16,26 +17,81 @@ def load_python_coverage(path: str = "coverage.json") -> dict[str, object] | Non
 
 
 def find_cobertura_xml(root: str = "artifacts/coverage-dotnet") -> str | None:
-    # Pick the newest run if multiple exist
+    # Pick the newest run if multiple exist.
     candidates = sorted(
-        glob.glob(os.path.join(root, "*/coverage.cobertura.xml")),
+        glob.glob(os.path.join(root, "*/coverage.cobertura.xml"))
+        + glob.glob(os.path.join(root, "coverage.cobertura.xml")),
         key=lambda p: os.path.getmtime(p),
     )
     return candidates[-1] if candidates else None
 
 
-def load_cobertura_summary(path: str) -> tuple[float, list[tuple[str, float]]]:
+def load_cobertura_summary(path: str) -> tuple[float, list[tuple[str, float]], list[tuple[str, int, int]]]:
     tree = ET.parse(path)
     root = tree.getroot()
     line_rate = float(root.attrib.get("line-rate", 0.0))
-    # Collect classes with lowest line-rate
     classes: list[tuple[str, float]] = []
+    files: list[tuple[str, int, int]] = []
     for cls in root.findall(".//class"):
         name = cls.attrib.get("filename") or cls.attrib.get("name") or "?"
         rate = float(cls.attrib.get("line-rate", 0.0))
         classes.append((name, rate))
+        lines = cls.findall(".//line")
+        total = len(lines)
+        hit = sum(1 for line in lines if int(line.attrib.get("hits", "0")) > 0)
+        files.append((name, hit, total))
     classes.sort(key=lambda x: x[1])
-    return line_rate, classes
+    return line_rate, classes, files
+
+
+def normalise_coverage_path(path: str) -> str:
+    return path.replace("\\", "/")
+
+
+def is_production_dotnet_source(path: str) -> bool:
+    # Scope .NET gate/reporting to executable production C# source files.
+    # Exclude generated paths and test projects.
+    normalised = normalise_coverage_path(path)
+    if not normalised.endswith(".cs"):
+        return False
+    if "/obj/" in normalised:
+        return False
+    if re.search(r"(^|/)DriftBuster\..*\.Tests(/|$)", normalised):
+        return False
+    return True
+
+
+def summarise_scoped_dotnet(files: list[tuple[str, int, int]]) -> tuple[float, list[tuple[str, int, int, float]]]:
+    aggregated: dict[str, tuple[int, int]] = {}
+    for name, hit, total in files:
+        normalised = normalise_coverage_path(name)
+        if not is_production_dotnet_source(normalised):
+            continue
+
+        previous = aggregated.get(normalised)
+        if previous is None:
+            aggregated[normalised] = (hit, total)
+            continue
+
+        prev_hit, prev_total = previous
+        aggregated[normalised] = (prev_hit + hit, prev_total + total)
+
+    scoped = [
+        (
+            name,
+            hit,
+            total,
+            (hit / total if total else 0.0),
+        )
+        for name, (hit, total) in aggregated.items()
+        if total > 0
+    ]
+    scoped.sort(key=lambda item: (item[3], -item[2], item[0]))
+
+    total_hit = sum(item[1] for item in scoped)
+    total_lines = sum(item[2] for item in scoped)
+    ratio = (total_hit / total_lines) if total_lines else 0.0
+    return ratio, scoped
 
 
 def percent(v: float) -> str:
@@ -47,6 +103,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--python-json", default="coverage.json")
     parser.add_argument("--dotnet-root", default="artifacts/coverage-dotnet")
     parser.add_argument("--top", type=int, default=5, help="Show top N most undercovered .NET classes")
+    parser.add_argument("--dotnet-threshold", type=float, default=90.0, help="Fail when scoped .NET coverage is below this percent.")
+    parser.add_argument("--enforce-dotnet-threshold", action="store_true", help="Return non-zero when scoped .NET coverage is below --dotnet-threshold.")
     args = parser.parse_args(argv)
 
     py = load_python_coverage(args.python_json)
@@ -62,17 +120,34 @@ def main(argv: list[str] | None = None) -> int:
         print(".NET coverage: Cobertura XML not found")
         return 0
 
-    line_rate, classes = load_cobertura_summary(cob)
-    print(f".NET coverage: {percent(line_rate)} (Cobertura)")
+    line_rate, classes, files = load_cobertura_summary(cob)
+    print(f".NET coverage (raw Cobertura): {percent(line_rate)}")
+
+    scoped_rate, scoped_files = summarise_scoped_dotnet(files)
+    print(f".NET coverage (scoped production .cs): {percent(scoped_rate)}")
+
+    if scoped_files:
+        print("Top undercovered scoped .NET files:")
+        for name, hit, total, rate in scoped_files[: args.top]:
+            print(f"- {name}: {percent(rate)} ({hit}/{total})")
+
     # Show undercovered GUI classes to guide test investment
     undercovered = [(n, r) for n, r in classes if n.startswith("DriftBuster.Gui/")]
     if undercovered:
         print("Top undercovered .NET GUI classes:")
         for name, rate in undercovered[: args.top]:
             print(f"- {name}: {percent(rate)}")
+
+    threshold_ratio = args.dotnet_threshold / 100.0
+    if args.enforce_dotnet_threshold and scoped_rate < threshold_ratio:
+        print(
+            f".NET scoped coverage check failed: {percent(scoped_rate)} "
+            f"is below required {args.dotnet_threshold:.2f}%."
+        )
+        return 1
+
     return 0
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -68,14 +68,20 @@ else
 fi
 
 echo ""
-echo "=== .NET scoped coverage guard (90%) ==="
+DOTNET_DIFF_BASE="${DOTNET_DIFF_BASE:-origin/main}"
+
+echo "=== .NET changed-line coverage guard (90%) vs ${DOTNET_DIFF_BASE} ==="
 coverage_report_log="$(mktemp)"
-if python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold >"${coverage_report_log}" 2>&1; then
+if python -m scripts.coverage_report \
+    --dotnet-threshold 90 \
+    --dotnet-diff-base "${DOTNET_DIFF_BASE}" \
+    --dotnet-enforce-scope changed \
+    --enforce-dotnet-threshold >"${coverage_report_log}" 2>&1; then
     cat "${coverage_report_log}"
-    echo "PASS: .NET scoped coverage"
+    echo "PASS: .NET changed-line coverage"
 else
     cat "${coverage_report_log}"
-    echo "FAIL: .NET scoped coverage below 90%"
+    echo "FAIL: .NET changed-line coverage below 90%"
     FAILURES=$((FAILURES + 1))
 fi
 rm -f "${coverage_report_log}"

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -68,6 +68,19 @@ else
 fi
 
 echo ""
+echo "=== .NET scoped coverage guard (90%) ==="
+coverage_report_log="$(mktemp)"
+if python -m scripts.coverage_report --dotnet-threshold 90 --enforce-dotnet-threshold >"${coverage_report_log}" 2>&1; then
+    cat "${coverage_report_log}"
+    echo "PASS: .NET scoped coverage"
+else
+    cat "${coverage_report_log}"
+    echo "FAIL: .NET scoped coverage below 90%"
+    FAILURES=$((FAILURES + 1))
+fi
+rm -f "${coverage_report_log}"
+
+echo ""
 echo "=== .NET format check ==="
 for proj in gui/DriftBuster.Backend/DriftBuster.Backend.csproj \
             gui/DriftBuster.Gui/DriftBuster.Gui.csproj \

--- a/scripts/verify_coverage.py
+++ b/scripts/verify_coverage.py
@@ -104,6 +104,9 @@ def build_summary_commands(opts: VerifyOptions) -> List[List[str]]:
             opts.python_json,
             "--dotnet-root",
             opts.dotnet_results_dir,
+            "--dotnet-threshold",
+            str(opts.dotnet_threshold),
+            "--enforce-dotnet-threshold",
         ]
     ]
 

--- a/scripts/verify_coverage.py
+++ b/scripts/verify_coverage.py
@@ -29,6 +29,8 @@ class VerifyOptions:
     perf_filter: str = "Category=PerfSmoke"
     python_threshold: int = 90
     dotnet_threshold: int = 90
+    dotnet_diff_base: str = "origin/main"
+    dotnet_enforce_scope: str = "changed"
     python_source: str = "src/driftbuster"
     python_json: str = "coverage.json"
     dotnet_project: str = (
@@ -106,6 +108,10 @@ def build_summary_commands(opts: VerifyOptions) -> List[List[str]]:
             opts.dotnet_results_dir,
             "--dotnet-threshold",
             str(opts.dotnet_threshold),
+            "--dotnet-diff-base",
+            opts.dotnet_diff_base,
+            "--dotnet-enforce-scope",
+            opts.dotnet_enforce_scope,
             "--enforce-dotnet-threshold",
         ]
     ]
@@ -239,6 +245,17 @@ def parse_args(argv: Sequence[str] | None = None) -> VerifyOptions:
         help="Fail coverage if .NET line coverage falls below this threshold.",
     )
     parser.add_argument(
+        "--dotnet-diff-base",
+        default="origin/main",
+        help="Git base ref used for changed-line .NET coverage enforcement.",
+    )
+    parser.add_argument(
+        "--dotnet-enforce-scope",
+        choices=("scoped", "changed"),
+        default="changed",
+        help="Coverage scope for the .NET summary threshold check.",
+    )
+    parser.add_argument(
         "--dotnet-project",
         default="gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj",
         help="Path to the .NET test project to execute.",
@@ -309,6 +326,8 @@ def parse_args(argv: Sequence[str] | None = None) -> VerifyOptions:
         perf_filter=args.perf_filter,
         python_threshold=args.python_threshold,
         dotnet_threshold=args.dotnet_threshold,
+        dotnet_diff_base=args.dotnet_diff_base,
+        dotnet_enforce_scope=args.dotnet_enforce_scope,
         python_source=args.python_source,
         python_json=args.python_json,
         dotnet_project=args.dotnet_project,

--- a/scripts/verify_coverage.sh
+++ b/scripts/verify_coverage.sh
@@ -62,9 +62,13 @@ dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj \
   --collect:"XPlat Code Coverage" \
   --results-directory artifacts/coverage-dotnet -v minimal
 
-echo "-- Repo-wide coverage summary (enforce .NET scoped threshold)"
+DOTNET_DIFF_BASE="${DOTNET_DIFF_BASE:-origin/main}"
+
+echo "-- Repo-wide coverage summary (enforce .NET changed-line threshold vs ${DOTNET_DIFF_BASE})"
 python -m scripts.coverage_report \
   --dotnet-threshold 90 \
+  --dotnet-diff-base "${DOTNET_DIFF_BASE}" \
+  --dotnet-enforce-scope changed \
   --enforce-dotnet-threshold
 
 echo "-- Coverage history snapshot"

--- a/scripts/verify_coverage.sh
+++ b/scripts/verify_coverage.sh
@@ -62,8 +62,10 @@ dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj \
   --collect:"XPlat Code Coverage" \
   --results-directory artifacts/coverage-dotnet -v minimal
 
-echo "-- Repo-wide coverage summary"
-python -m scripts.coverage_report || true
+echo "-- Repo-wide coverage summary (enforce .NET scoped threshold)"
+python -m scripts.coverage_report \
+  --dotnet-threshold 90 \
+  --enforce-dotnet-threshold
 
 echo "-- Coverage history snapshot"
 python -m scripts.coverage_history --python-json coverage.json \
@@ -84,4 +86,3 @@ if [[ "${RUN_PERF_SMOKE}" == "true" ]]; then
 fi
 
 echo "== Coverage verification complete =="
-

--- a/scripts/verify_coverage.sh
+++ b/scripts/verify_coverage.sh
@@ -74,6 +74,7 @@ python -m scripts.coverage_report \
 echo "-- Coverage history snapshot"
 python -m scripts.coverage_history --python-json coverage.json \
   --dotnet-root artifacts/coverage-dotnet \
+  --dotnet-diff-base "${DOTNET_DIFF_BASE}" \
   --output artifacts/coverage/history.csv \
   --notes "verify_coverage"
 

--- a/scripts/vm-automation.ps1
+++ b/scripts/vm-automation.ps1
@@ -1,0 +1,73 @@
+# DriftBuster GUI Automation Helper
+# Sends JSON commands to the DriftBuster automation named pipe.
+# Usage:
+#   . C:\DriftBusterTest\vm-automation.ps1
+#   Send-DriftBusterCommand 'DriftBuster-Automation-1234' @{cmd='ping'}
+#   Send-DriftBusterCommand 'DriftBuster-Automation-1234' @{cmd='navigate'; tab='multi-server'}
+#   Send-DriftBusterCommand 'DriftBuster-Automation-1234' @{cmd='get-state'}
+
+function Send-DriftBusterCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$PipeName,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Command,
+
+        [int]$TimeoutMs = 10000
+    )
+
+    $pipe = $null
+    $writer = $null
+    $reader = $null
+
+    try {
+        $pipe = New-Object System.IO.Pipes.NamedPipeClientStream('.', $PipeName, 'InOut')
+        $pipe.Connect($TimeoutMs)
+
+        $writer = New-Object System.IO.StreamWriter($pipe)
+        $writer.AutoFlush = $true
+        $reader = New-Object System.IO.StreamReader($pipe)
+
+        $json = $Command | ConvertTo-Json -Compress -Depth 10
+        $writer.WriteLine($json)
+
+        $response = $reader.ReadLine()
+
+        if ($null -eq $response) {
+            Write-Error "No response received from automation server."
+            return $null
+        }
+
+        return $response | ConvertFrom-Json
+    }
+    catch {
+        Write-Error "Automation command failed: $_"
+        return $null
+    }
+    finally {
+        if ($null -ne $reader) { $reader.Dispose() }
+        if ($null -ne $writer) { $writer.Dispose() }
+        if ($null -ne $pipe) { $pipe.Dispose() }
+    }
+}
+
+function Find-DriftBusterPipe {
+    [CmdletBinding()]
+    param()
+
+    $pipes = Get-ChildItem "\\.\pipe\" -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like 'DriftBuster-Automation-*' }
+
+    if ($null -eq $pipes -or $pipes.Count -eq 0) {
+        Write-Warning "No DriftBuster automation pipes found. Is the GUI running with DRIFTBUSTER_AUTOMATION=1?"
+        return $null
+    }
+
+    foreach ($p in $pipes) {
+        Write-Host "Found pipe: $($p.Name)"
+    }
+
+    return $pipes[0].Name
+}

--- a/scripts/vm-automation.ps1
+++ b/scripts/vm-automation.ps1
@@ -4,6 +4,8 @@
 #   . C:\DriftBusterTest\vm-automation.ps1
 #   Send-DriftBusterCommand 'DriftBuster-Automation-1234' @{cmd='ping'}
 #   Send-DriftBusterCommand 'DriftBuster-Automation-1234' @{cmd='navigate'; tab='multi-server'}
+#   Send-DriftBusterCommand 'DriftBuster-Automation-1234' @{cmd='run-all'}
+#   Wait-DriftBusterIdle 'DriftBuster-Automation-1234' -TimeoutSeconds 120
 #   Send-DriftBusterCommand 'DriftBuster-Automation-1234' @{cmd='get-state'}
 
 function Send-DriftBusterCommand {
@@ -70,4 +72,56 @@ function Find-DriftBusterPipe {
     }
 
     return $pipes[0].Name
+}
+
+function Wait-DriftBusterIdle {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$PipeName,
+
+        [int]$TimeoutSeconds = 120,
+
+        [int]$PollIntervalMs = 500
+    )
+
+    if ($TimeoutSeconds -le 0) {
+        Write-Error "TimeoutSeconds must be greater than zero."
+        return $null
+    }
+
+    if ($PollIntervalMs -le 0) {
+        Write-Error "PollIntervalMs must be greater than zero."
+        return $null
+    }
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+
+    while ((Get-Date) -lt $deadline) {
+        $stateResponse = Send-DriftBusterCommand -PipeName $PipeName -Command @{ cmd = 'get-state' }
+        if ($null -eq $stateResponse) {
+            Start-Sleep -Milliseconds $PollIntervalMs
+            continue
+        }
+
+        if (-not $stateResponse.ok) {
+            Write-Error "get-state failed while waiting for idle: $($stateResponse.error)"
+            return $null
+        }
+
+        $state = $stateResponse.data
+        if ($null -eq $state -or -not ($state.PSObject.Properties.Name -contains 'isBusy')) {
+            Write-Error "State response does not include 'isBusy'. Navigate to multi-server before waiting for idle."
+            return $null
+        }
+
+        if (-not [bool]$state.isBusy) {
+            return $stateResponse
+        }
+
+        Start-Sleep -Milliseconds $PollIntervalMs
+    }
+
+    Write-Error "Timed out after $TimeoutSeconds seconds waiting for DriftBuster to become idle."
+    return $null
 }

--- a/tests/scripts/test_coverage_history.py
+++ b/tests/scripts/test_coverage_history.py
@@ -42,7 +42,7 @@ def test_append_history_writes_changed_dotnet_column(tmp_path: Path) -> None:
     ]
 
 
-def test_append_history_keeps_legacy_layout_when_existing_file_is_legacy(tmp_path: Path) -> None:
+def test_append_history_migrates_legacy_layout_when_existing_file_is_legacy(tmp_path: Path) -> None:
     output = tmp_path / "legacy-history.csv"
     output.write_text(
         "timestamp_utc,python_percent,dotnet_percent,python_watch_min,notes\n"
@@ -67,13 +67,23 @@ def test_append_history_keeps_legacy_layout_when_existing_file_is_legacy(tmp_pat
         "timestamp_utc",
         "python_percent",
         "dotnet_percent",
+        "dotnet_changed_percent",
         "python_watch_min",
         "notes",
+    ]
+    assert rows[1] == [
+        "2026-03-03T00:00:00+00:00",
+        "93.00",
+        "81.00",
+        "",
+        "90.00",
+        "old",
     ]
     assert rows[-1] == [
         "2026-03-04T08:00:00+00:00",
         "93.41",
         "81.54",
+        "90.68",
         "90.91",
         "verify",
     ]

--- a/tests/scripts/test_coverage_history.py
+++ b/tests/scripts/test_coverage_history.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from scripts import coverage_history
+
+
+def test_append_history_writes_changed_dotnet_column(tmp_path: Path) -> None:
+    output = tmp_path / "history.csv"
+
+    coverage_history.append_history(
+        output_path=output,
+        timestamp="2026-03-04T08:00:00+00:00",
+        python_percent=93.41,
+        dotnet_percent=81.54,
+        dotnet_changed_percent=90.68,
+        watch_lowest=90.91,
+        notes="verify",
+    )
+
+    with output.open("r", encoding="utf-8", newline="") as fh:
+        rows = list(csv.reader(fh))
+
+    assert rows[0] == [
+        "timestamp_utc",
+        "python_percent",
+        "dotnet_percent",
+        "dotnet_changed_percent",
+        "python_watch_min",
+        "notes",
+    ]
+    assert rows[1] == [
+        "2026-03-04T08:00:00+00:00",
+        "93.41",
+        "81.54",
+        "90.68",
+        "90.91",
+        "verify",
+    ]
+
+
+def test_append_history_keeps_legacy_layout_when_existing_file_is_legacy(tmp_path: Path) -> None:
+    output = tmp_path / "legacy-history.csv"
+    output.write_text(
+        "timestamp_utc,python_percent,dotnet_percent,python_watch_min,notes\n"
+        "2026-03-03T00:00:00+00:00,93.00,81.00,90.00,old\n",
+        encoding="utf-8",
+    )
+
+    coverage_history.append_history(
+        output_path=output,
+        timestamp="2026-03-04T08:00:00+00:00",
+        python_percent=93.41,
+        dotnet_percent=81.54,
+        dotnet_changed_percent=90.68,
+        watch_lowest=90.91,
+        notes="verify",
+    )
+
+    with output.open("r", encoding="utf-8", newline="") as fh:
+        rows = list(csv.reader(fh))
+
+    assert rows[0] == [
+        "timestamp_utc",
+        "python_percent",
+        "dotnet_percent",
+        "python_watch_min",
+        "notes",
+    ]
+    assert rows[-1] == [
+        "2026-03-04T08:00:00+00:00",
+        "93.41",
+        "81.54",
+        "90.91",
+        "verify",
+    ]
+
+
+def test_compute_dotnet_changed_percent_uses_changed_ratio(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(coverage_history, "find_cobertura_xml", lambda _root: "fake.xml")
+    monkeypatch.setattr(
+        coverage_history,
+        "load_cobertura_summary",
+        lambda _path: (0.81, [], [], {"gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs": {10: 1}}),
+    )
+    monkeypatch.setattr(
+        coverage_history,
+        "load_changed_production_lines",
+        lambda _base: {"gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs": {10}},
+    )
+    monkeypatch.setattr(
+        coverage_history,
+        "summarise_changed_dotnet_lines",
+        lambda _changed, _hits: (0.9068, [], []),
+    )
+
+    percent = coverage_history.compute_dotnet_changed_percent(Path("artifacts/coverage-dotnet"), "origin/main")
+
+    assert percent == 90.68
+
+
+def test_compute_dotnet_changed_percent_returns_none_without_coverage_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(coverage_history, "find_cobertura_xml", lambda _root: None)
+
+    percent = coverage_history.compute_dotnet_changed_percent(Path("artifacts/coverage-dotnet"), "origin/main")
+
+    assert percent is None

--- a/tests/scripts/test_coverage_history.py
+++ b/tests/scripts/test_coverage_history.py
@@ -120,3 +120,23 @@ def test_compute_dotnet_changed_percent_returns_none_without_coverage_report(
     percent = coverage_history.compute_dotnet_changed_percent(Path("artifacts/coverage-dotnet"), "origin/main")
 
     assert percent is None
+
+
+def test_compute_dotnet_changed_percent_returns_none_when_diff_resolution_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(coverage_history, "find_cobertura_xml", lambda _root: "fake.xml")
+    monkeypatch.setattr(
+        coverage_history,
+        "load_cobertura_summary",
+        lambda _path: (0.81, [], [], {"gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs": {10: 1}}),
+    )
+
+    def raise_runtime(_base: str) -> dict[str, set[int]]:
+        raise RuntimeError("bad ref")
+
+    monkeypatch.setattr(coverage_history, "load_changed_production_lines", raise_runtime)
+
+    percent = coverage_history.compute_dotnet_changed_percent(Path("artifacts/coverage-dotnet"), "origin/main")
+
+    assert percent is None

--- a/tests/scripts/test_coverage_report.py
+++ b/tests/scripts/test_coverage_report.py
@@ -5,10 +5,12 @@ from pathlib import Path
 
 import pytest
 
+from scripts import coverage_report as coverage_report_module
 from scripts.coverage_report import (
     coverage_path_candidates,
     load_changed_production_lines,
     load_cobertura_summary,
+    main as coverage_report_main,
     summarise_changed_dotnet_lines,
 )
 
@@ -122,3 +124,19 @@ def test_load_cobertura_summary_builds_line_hit_aliases(tmp_path: Path) -> None:
 
     assert line_hits["DriftBuster.Gui/ViewModels/MainWindowViewModel.cs"][10] == 1
     assert line_hits["gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs"][11] == 0
+
+
+def test_main_fails_when_enforcement_enabled_and_cobertura_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(coverage_report_module, "find_cobertura_xml", lambda _root: None)
+
+    result = coverage_report_main(
+        [
+            "--python-json",
+            "missing-coverage.json",
+            "--enforce-dotnet-threshold",
+        ]
+    )
+
+    assert result == 1

--- a/tests/scripts/test_coverage_report.py
+++ b/tests/scripts/test_coverage_report.py
@@ -48,7 +48,7 @@ diff --git a/gui/DriftBuster.Gui.Tests/ViewModels/MainWindowViewModelTests.cs b/
     }
 
 
-def test_load_changed_production_lines_returns_empty_when_git_unavailable(
+def test_load_changed_production_lines_raises_when_git_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_check_output(*_args, **_kwargs) -> str:
@@ -56,7 +56,8 @@ def test_load_changed_production_lines_returns_empty_when_git_unavailable(
 
     monkeypatch.setattr(subprocess, "check_output", fake_check_output)
 
-    assert load_changed_production_lines("origin/main") == {}
+    with pytest.raises(RuntimeError, match="unable to compute git diff"):
+        load_changed_production_lines("origin/main")
 
 
 def test_summarise_changed_dotnet_lines_counts_only_executable_lines() -> None:

--- a/tests/scripts/test_coverage_report.py
+++ b/tests/scripts/test_coverage_report.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.coverage_report import (
+    coverage_path_candidates,
+    load_changed_production_lines,
+    load_cobertura_summary,
+    summarise_changed_dotnet_lines,
+)
+
+
+def test_coverage_path_candidates_adds_repo_relative_alias() -> None:
+    candidates = coverage_path_candidates("DriftBuster.Gui/ViewModels/MainWindowViewModel.cs")
+
+    assert "DriftBuster.Gui/ViewModels/MainWindowViewModel.cs" in candidates
+    assert "gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs" in candidates
+
+
+def test_load_changed_production_lines_parses_hunks_and_filters_non_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    diff = """diff --git a/gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs b/gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs
++++ b/gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs
+@@ -10,0 +11,2 @@
++line a
++line b
+@@ -30,1 +33 @@
++line c
+diff --git a/gui/DriftBuster.Gui.Tests/ViewModels/MainWindowViewModelTests.cs b/gui/DriftBuster.Gui.Tests/ViewModels/MainWindowViewModelTests.cs
++++ b/gui/DriftBuster.Gui.Tests/ViewModels/MainWindowViewModelTests.cs
+@@ -1 +1 @@
++ignored
+"""
+
+    def fake_check_output(*_args, **_kwargs) -> str:
+        return diff
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    changed = load_changed_production_lines("origin/main")
+
+    assert changed == {
+        "gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs": {11, 12, 33}
+    }
+
+
+def test_load_changed_production_lines_returns_empty_when_git_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_check_output(*_args, **_kwargs) -> str:
+        raise subprocess.CalledProcessError(returncode=1, cmd=["git"])
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    assert load_changed_production_lines("origin/main") == {}
+
+
+def test_summarise_changed_dotnet_lines_counts_only_executable_lines() -> None:
+    changed = {
+        "gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs": {10, 11, 12},
+        "gui/DriftBuster.Gui/ViewModels/NoExecutableHitMap.cs": {5},
+    }
+    line_hits = {
+        "gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs": {
+            10: 1,
+            11: 0,
+            # 12 intentionally omitted (non-executable)
+        }
+    }
+
+    ratio, details, skipped = summarise_changed_dotnet_lines(changed, line_hits)
+
+    assert ratio == 0.5
+    assert details == [
+        (
+            "gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs",
+            1,
+            2,
+            0.5,
+        )
+    ]
+    assert skipped == ["gui/DriftBuster.Gui/ViewModels/NoExecutableHitMap.cs"]
+
+
+def test_summarise_changed_dotnet_lines_returns_none_when_no_executable_lines() -> None:
+    ratio, details, skipped = summarise_changed_dotnet_lines(
+        {"gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs": {1, 2}},
+        {},
+    )
+
+    assert ratio is None
+    assert details == []
+    assert skipped == ["gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs"]
+
+
+def test_load_cobertura_summary_builds_line_hit_aliases(tmp_path: Path) -> None:
+    xml = """<?xml version="1.0" ?>
+<coverage line-rate="0.5">
+  <packages>
+    <package name="DriftBuster.Gui">
+      <classes>
+        <class name="MainWindowViewModel" filename="DriftBuster.Gui/ViewModels/MainWindowViewModel.cs" line-rate="0.5">
+          <lines>
+            <line number="10" hits="1"/>
+            <line number="11" hits="0"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+"""
+    path = tmp_path / "coverage.cobertura.xml"
+    path.write_text(xml, encoding="utf-8")
+
+    _line_rate, _classes, _files, line_hits = load_cobertura_summary(str(path))
+
+    assert line_hits["DriftBuster.Gui/ViewModels/MainWindowViewModel.cs"][10] == 1
+    assert line_hits["gui/DriftBuster.Gui/ViewModels/MainWindowViewModel.cs"][11] == 0

--- a/tests/scripts/test_verify_coverage.py
+++ b/tests/scripts/test_verify_coverage.py
@@ -53,15 +53,7 @@ def test_default_verify_runs_all_sections(tmp_path: Path) -> None:
     assert ["coverage", "report", f"--fail-under={opts.python_threshold}"] in recorder.commands
     assert ["coverage", "json", "-o", opts.python_json] in recorder.commands
     assert any(cmd[:2] == ["dotnet", "test"] for cmd in recorder.commands)
-    summary_cmd = [
-        sys.executable,
-        "-m",
-        "scripts.coverage_report",
-        "--python-json",
-        opts.python_json,
-        "--dotnet-root",
-        opts.dotnet_results_dir,
-    ]
+    summary_cmd = build_summary_commands(opts)[0]
     assert summary_cmd in recorder.commands
 
 
@@ -104,7 +96,14 @@ def test_build_dotnet_commands_creates_directory(tmp_path: Path) -> None:
 def test_build_summary_commands_uses_configured_paths() -> None:
     opts = VerifyOptions(python_json="out.json", dotnet_results_dir="dotnet-out")
     commands = build_summary_commands(opts)
-    assert commands[0][-2:] == ["--dotnet-root", "dotnet-out"]
+    command = commands[0]
+    assert command[0:3] == [sys.executable, "-m", "scripts.coverage_report"]
+    assert "--dotnet-root" in command
+    assert command[command.index("--dotnet-root") + 1] == "dotnet-out"
+    assert "--dotnet-diff-base" in command
+    assert command[command.index("--dotnet-diff-base") + 1] == opts.dotnet_diff_base
+    assert "--dotnet-enforce-scope" in command
+    assert command[command.index("--dotnet-enforce-scope") + 1] == opts.dotnet_enforce_scope
 
 
 def test_enforce_python_module_thresholds_pass(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add UI-thread dispatch timeout protection in `AutomationServer` with configurable env override (`DRIFTBUSTER_AUTOMATION_UI_DISPATCH_TIMEOUT_MS`, default 30s)
- extend automation `navigate` to support multi-server sub-views: `multi-server/setup`, `multi-server/catalog`, `multi-server/drilldown` (and `multiserver/...`)
- add `Wait-DriftBusterIdle` helper to `scripts/vm-automation.ps1` so scripts can block until `isBusy` becomes false
- bump `global.json` SDK pin from `10.0.101` to `10.0.103` while keeping `rollForward: latestPatch`
- add and stabilize targeted GUI/unit coverage for paths/converters/toasts/layout/session/mru/main-window/server-selection behavior
- harden `BuildSessionSnapshot` to avoid null-reference failures while saving session state after scan activity
- update coverage tooling and local guard scripts to enforce the 90% .NET threshold on changed production `.cs` executable lines (vs `origin/main`) while still reporting full scoped production coverage for backlog visibility
- make changed-line coverage enforcement fail closed when git diff context cannot be resolved and when Cobertura XML is missing during enforcement
- migrate legacy coverage history CSV schema to include `dotnet_changed_percent` and add script tests for diff parsing/aliasing/history behavior

## Verification
- `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj -v minimal`
- `dotnet test gui/DriftBuster.Gui.Tests/DriftBuster.Gui.Tests.csproj -p:Threshold=90 -p:ThresholdType=line -p:ThresholdStat=total --collect:"XPlat Code Coverage" --results-directory artifacts/coverage-dotnet -v minimal`
- `pytest -q tests/scripts/test_verify_coverage.py tests/scripts/test_coverage_report.py tests/scripts/test_coverage_history.py`
- `python -m scripts.coverage_report --dotnet-threshold 90 --dotnet-diff-base origin/main --dotnet-enforce-scope changed --enforce-dotnet-threshold`
- `scripts/verify_coverage.sh`

## Coverage Snapshot (latest)
- Python coverage: 93.41%
- .NET raw Cobertura: 81.62%
- .NET scoped production `.cs`: 82.63%
- .NET changed production `.cs` executable lines vs `origin/main`: 97.06% (132/136)

Closes #19
Closes #20
Closes #21
Closes #22
